### PR TITLE
00_SIGNALduino - fix PERL WARNING

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -4151,7 +4151,7 @@ sub SIGNALduino_callsub
 		
 		my ($rcode, @returnvalues) = $method->($name, @args) ;	
 			
-	    SIGNALduino_Log3 $name, 5, "$name: modified value after $funcname: @returnvalues";
+	    SIGNALduino_Log3 $name, 5, "$name: modified value after $funcname:".@returnvalues;
 	    return ($rcode, @returnvalues);
 	} elsif (defined $method ) {					
 		SIGNALduino_Log3 $name, 5, "$name: Error: Unknown method $funcname Please check definition";


### PR DESCRIPTION
PERL WARNING: Use of uninitialized value $returnvalues[0] in join or string at ./FHEM/00_SIGNALduino.pm line