### PR TITLE
Update FS10.pm, add "sendMsgCombined" and "pause" to SIGNALduino.pm

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -4288,8 +4288,6 @@ sub SIGNALduino_postDemo_FS20($@) {
 	my $sum = 6;
 	my $b = 0;
 	my $i = 0;
-	
-	
    for ($datastart = 0; $datastart < $protolength; $datastart++) {   # Start bei erstem Bit mit Wert 1 suchen
       last if $bit_msg[$datastart] eq "1";
    }
@@ -4305,7 +4303,7 @@ sub SIGNALduino_postDemo_FS20($@) {
       }
       my $checksum = oct( "0b".(join "", @bit_msg[$protolength - 9 .. $protolength - 2]));   # Checksum Byte 5 or 6
       if (($sum & 0xFF) == $checksum) {				            ## FH20 remote control
-			for(my $b = 0; $b < $protolength - 9; $b += 9) {	            # check parity over 5 or 6 bytes
+			for(my $b = 0; $b < $protolength; $b += 9) {	            # check parity over 5 or 6 bytes
 				my $parity = 0;					                                 # Parity even
 				for(my $i = $b; $i < $b + 9; $i++) {			                  # Parity over 1 byte + 1 bit
 					$parity += $bit_msg[$i];
@@ -4339,7 +4337,6 @@ sub SIGNALduino_postDemo_FHT80($@) {
 	my $sum = 12;
 	my $b = 0;
 	my $i = 0;
-
    for ($datastart = 0; $datastart < $protolength; $datastart++) {   # Start bei erstem Bit mit Wert 1 suchen
       last if $bit_msg[$datastart] eq "1";
    }
@@ -4355,7 +4352,7 @@ sub SIGNALduino_postDemo_FHT80($@) {
       }
       my $checksum = oct( "0b".(join "", @bit_msg[45 .. 52]));          # Checksum Byte 6
       if (($sum & 0xFF) == $checksum) {								## FHT80 Raumthermostat
-         for($b = 0; $b < 55; $b += 9) {	                              # check parity over 6 byte
+         for($b = 0; $b < 54; $b += 9) {	                              # check parity over 6 byte
             my $parity = 0;					                              # Parity even
             for($i = $b; $i < $b + 9; $i++) {			                  # Parity over 1 byte + 1 bit
                $parity += $bit_msg[$i];
@@ -4396,7 +4393,7 @@ sub SIGNALduino_postDemo_FHT80TF($@) {
       last if $bit_msg[$datastart] eq "1";
    }
    if ($datastart == $protolength) {                                 # all bits are 0
-		SIGNALduino_Log3 $name, 3, "$name: FHTTF - ERROR message all bit are zeros";
+		SIGNALduino_Log3 $name, 3, "$name: FHT80TF - ERROR message all bit are zeros";
 		return 0, undef;
    }
    splice(@bit_msg, 0, $datastart + 1);                             	# delete preamble + 1 bit
@@ -4426,7 +4423,7 @@ sub SIGNALduino_postDemo_FHT80TF($@) {
          }
 			splice(@bit_msg, 32, 8);                                       # delete checksum
 				my $dmsg = SIGNALduino_b2h(join "", @bit_msg);
-				SIGNALduino_Log3 $name, 4, "$name: FHT80 - roomthermostat post demodulation $dmsg";
+				SIGNALduino_Log3 $name, 4, "$name: FHT80TF - door/window switch post demodulation $dmsg";
 			return (1, @bit_msg);											## FHT80TF ok
       } 
    } 

--- a/FHEM/10_FS10.pm
+++ b/FHEM/10_FS10.pm
@@ -3,12 +3,13 @@
 #
 # FS10 basierend auf dem FS20 Modul angepasst für SIGNALduino, elektron-bbs
 #
-# 2017-11-25  FS10_Set          Checksumme für Wiederholung wurde falsch berechnet
-#                               Pause zwischen Wiederholung jetzt immer 200 mS
-#                               SignalRepeats jetzt auch im Abstand von 200 mS
-#                               Anzahl Wiederholungen bei Dimm-Befehlen korrigiert
-#                               Anzahl Dimup/Dimdown auf 1-10 begrenzt
-#             FS10_Initialize   Anzahl Wiederholungen auf 1 bis 9 begrenzt
+# 2017-12-28  FS10_Set          	Checksumme für Wiederholung wurde falsch berechnet
+#                               	Pause zwischen Wiederholung jetzt immer 200 mS
+#                               	SignalRepeats jetzt auch im Abstand von 200 mS
+#                               	Anzahl Wiederholungen bei Dimm-Befehlen korrigiert
+#                               	Anzahl Dimup/Dimdown auf 1-10 begrenzt
+#											keine Wiederholungen bei Markisensteuerung	
+#             FS10_Initialize   	Anzahl Wiederholungen auf 1 bis 9 begrenzt
 package main;
 
 use strict;


### PR DESCRIPTION
SIGNALduino:
neu "sendMsgCombined"
neues Pattern "pause"
Definitionen FS10 und FS20 korrigiert

FS10:
Checksumme für Wiederholung wurde falsch berechnet
Pause zwischen Wiederholung jetzt immer 200 mS
SignalRepeats jetzt auch im Abstand von 200 mS
Anzahl Wiederholungen bei Dimm-Befehlen korrigiert
Anzahl Dimup/Dimdown auf 1-10 begrenzt
keine Wiederholungen bei Markisensteuerung	
Anzahl Wiederholungen auf 1 bis 9 begrenzt