### PR TITLE
00_SIGNALduino.pm - Anpassung Loglevel

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -4166,7 +4166,7 @@ sub SIGNALduino_IdList($@)
 		}
 		if ($bflag == 1 && defined($BlacklistIDs{$id}))
 		{
-			SIGNALduino_Log3 $name, 3, "$name skip Blacklist ID $id";
+			SIGNALduino_Log3 $name, 4, "$name skip Blacklist ID $id";
 			next;
 		}
 		

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -4150,7 +4150,7 @@ sub SIGNALduino_IdList($@)
 		if (defined($blacklist) && length($blacklist)>0) {
 			%BlacklistIDs = map { $_ => 1 } split(",", $blacklist);
 			my $w = join ', ' => map "$_" => keys %BlacklistIDs;
-			SIGNALduino_Log3 $name, 3, "$name Attr blacklist $w";
+			SIGNALduino_Log3 $name, 4, "$name Attr blacklist $w";
 			$bflag = 1;
 		}
 	}


### PR DESCRIPTION
- Anpassung Loglevel, da sonst "doppelte Ausgabe"

2018.04.01 12:22:02 3: signalESP sduinoIdList: whitelistIds=
**2018.04.01 12:22:02 3: signalESP sduinoIdList: blacklistIds=6,7,20,40,52,57**
2018.04.01 12:22:02 3: signalESP sduinoIdList: development=
2018.04.01 12:22:02 3: signalESP Attr blacklist 40, 57, 6, 7, 20, 52
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 52
2018.04.01 12:22:02 3: signalESP: ID=p76 skiped (developId=p)
2018.04.01 12:22:02 3: signalESP: ID=78 skiped (developId=y)
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 7
2018.04.01 12:22:02 3: signalESP: ID=73.1 skiped (developId=y)
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 57
2018.04.01 12:22:02 3: signalESP: ID=73 skiped (developId=y)
2018.04.01 12:22:02 3: signalESP: ID=74 skiped (developId=y)
2018.04.01 12:22:02 3: signalESP: ID=p76.1 skiped (developId=p)
2018.04.01 12:22:02 3: signalESP: ID=77 skiped (developId=y)
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 20
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 40
2018.04.01 12:22:02 3: signalESP skip Blacklist ID 6
2018.04.01 12:22:02 3: signalESP: ID=63 skiped (developId=y)