### PR TITLE
signalduino_protocols.hash - revised length_max IT

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,5 +1,5 @@
 18.10.2018
- signalduino_protocols.hash - doc added & sorted explanation
+ signalduino_protocols.hash - doc added & sorted explanation | ID 3,3.1,4,5,17,65 length_max definded
  14_SD_RSL.pm - added Doc_DE | Logoutput revised
 09.10.2018
  90_SIGNALduino_un.pm - added bitCountLength & added doc 

--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -120,7 +120,7 @@
 			clientmodule    => 'IT',   # not used now
 			modulematch     => '^i......', # not used now
 			length_min      => '24',
-			#length_max      => '800',		# Don't know maximal lenth of a valid message
+			length_max      => '24',		# Don't know maximal lenth of a valid message
 
 			},
     "3.1"    => # MS;P0=-11440;P1=-1121;P2=-416;P5=309;P6=1017;D=150516251515162516251625162516251515151516251625151;CP=5;SP=0;R=66;
@@ -139,7 +139,7 @@
 			clientmodule    => 'IT',   # not used now
 			modulematch     => '^i......', # not used now
 			length_min      => '24',
-			#length_max      => '800',		# Don't know maximal lenth of a valid message
+			length_max      => '24',		# Don't know maximal lenth of a valid message
 			postDemodulation => \&SIGNALduino_bit2itv1,
 			},
     "4"    => 
@@ -158,8 +158,8 @@
 			postamble		=> '00',		# Append to converted message	 	
 			clientmodule    => 'IT',   		# not used now
 			modulematch     => '^i......',  # not used now
-			length_min      => '32',
-			#length_max      => '76',		# Don't know maximal lenth of a valid message
+			length_min      => '39',
+			length_max      => '44',		# Don't know maximal lenth of a valid message
 		},
     "5"    => 	## Similar protocol as intertechno, but without sync
 				# ! same definition how ID 75, but other length !
@@ -175,6 +175,7 @@
 			clientmodule    => 'IT',   		# not used now
 			modulematch     => '^i......',  # not used now
 			length_min      => '24',
+			length_max      => '24',		# Don't know maximal lenth of a valid message
 
 		},    
 	
@@ -415,7 +416,7 @@
 			clientmodule    => 'IT',   		# not used now
 			modulematch     => '^i......',  # not used now
 			length_min      => '32',
-			#length_max     => '76',		# Don't know maximal lenth of a valid message
+			length_max      => '34',		# Don't know maximal lenth of a valid message
 			postDemodulation => \&SIGNALduino_bit2Arctec,
 		},
 	 "17.1"	=> # intertechno --> MU anstatt sonst MS (ID 17)
@@ -1234,6 +1235,7 @@
 			preamble     => 'ih',
 			clientmodule => 'IT',
 			length_min   => '57',
+			length_max   => '72',
 			postDemodulation => \&SIGNALduino_HE_EU,
 		},
 	"66" => ## TX2 Protocol (Remote Temp Transmitter & Remote Thermo Model 7035)


### PR DESCRIPTION
- ID 3,3.1,4,5,17,65 length_max definded
- length is given by the module --> without adaptation, misinterpretations

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Limitation and avoidance of false signals , module warning always when signal too long / short


* **What is the current behavior?** (You can also link to an open issue here)
- zu große Spannen wo das Modul vermehrt Fehlermeldungen generieren kann