### PR TITLE
00_SIGNALduino.pm - output

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,5 +1,5 @@
 12.11.2018
- 00_SIGNALduino - Firmware can be downloaded and flashed on demand from gitghub releases
+ 00_SIGNALduino - Firmware can be downloaded and flashed on demand from gitghub releases & remove double logoutput
 11.11.2018
  14_FLAMINGO.pm - fix Maintainer & fix issue error
 10.11.2018

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -2754,21 +2754,18 @@ SIGNALduino_Attr(@)
 	}
 	elsif ($aName eq "whitelist_IDs")
 	{
-		SIGNALduino_Log3 $name, 3, "$name Attr: whitelist_IDs";
 		if ($init_done) {		# beim fhem Start wird das SIGNALduino_IdList nicht aufgerufen, da es beim define aufgerufen wird
 			SIGNALduino_IdList("x:$name",$aVal);
 		}
 	}
 	elsif ($aName eq "blacklist_IDs")
 	{
-		SIGNALduino_Log3 $name, 3, "$name Attr: blacklist_IDs";
 		if ($init_done) {		# beim fhem Start wird das SIGNALduino_IdList nicht aufgerufen, da es beim define aufgerufen wird
 			SIGNALduino_IdList("x:$name",undef,$aVal);
 		}
 	}
 	elsif ($aName eq "development")
 	{
-		SIGNALduino_Log3 $name, 3, "$name Attr: development";
 		if ($init_done) {		# beim fhem Start wird das SIGNALduino_IdList nicht aufgerufen, da es beim define aufgerufen wird
 			SIGNALduino_IdList("x:$name",undef,undef,$aVal);
 		}


### PR DESCRIPTION
- remove OLD output double!!!

SIGNALduino_Log3 $name, 3, "$name Attr: development";
--> same how IDlist development

SIGNALduino_Log3 $name, 3, "$name Attr: blacklist_IDs";
--> same how IDlist blacklist

SIGNALduino_Log3 $name, 3, "$name Attr: whitelist_IDs";
--> same how IDlist whitelist

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- remove double output


* **What is the current behavior?** (You can also link to an open issue here)
- same output after FHEM restart

