### PR TITLE
signalduino_protocols.hash - length PFR-130

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,4 +1,5 @@
 13.11.2018
+ signalduino_protocols.hash - adaptation length PFR-130
  00_SIGNALduino.pm - added missingModulCheck | remove double logoutput
 12.11.2018
  14_SD_UT.pm - added devices QUIGG GT-7000 |Novy Pureline 6830 kitchen hood|CAME Drehtor Antrieb (develop - user feedback required)

--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -1322,7 +1322,7 @@
       		preamble		=> 's',			# prepend to converted message	 	
 			postamble		=> '00',		# Append to converted message	 	
 			clientmodule    => 'CUL_TCM97001',
-     		length_min      => '24',
+     		length_min      => '36',
 			length_max      => '42',
 			paddingbits     => '8',				 # pad up to 8 bits, default is 4
 		}, 	


### PR DESCRIPTION
- adaptation length (all MSG are lengh 40 from https://forum.fhem.de/index.php/topic,58397.msg655996.html#msg655996 or FORUM and here https://www.mikrocontroller.net/topic/398427 is a lengh from 36)  24 is to SHORT

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] CHANGED has been updated (for bug fixes / features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fewer error detections


* **What is the current behavior?** (You can also link to an open issue here)
- any sensors are decode because not the right sensor
