### PR TITLE
Update 98_unittest.pm

### DIFF
--- a/test/98_unittest.pm
+++ b/test/98_unittest.pm
@@ -275,6 +275,7 @@ sub UnitTest_mock_log3
 =item summary_DE Hilfsmodul was es ermöglicht unit test auszuführen
 
 =begin html
+
  <a name="UnitTest"></a>
  <h3>UnitTest</h3><br>
   
@@ -317,14 +318,14 @@ sub UnitTest_mock_log3
 			developId		=> 'm',
 	 },<br>
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;SIGNALduino_IdList("x:$target","","","m9999");<br>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;is($Log3->called_count-$ref_called_count,$ref_called_count+1,"SIGNALduino_Log3 output increased");<br>
-  &nbsp;&nbsp;&nbsp;&nbsp;}<br>
-  &nbsp;&nbsp;);
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;is($Log3->called_count-$ref_called_count,$ref_called_count+1,"SIGNALduino_Log3 output increased");})
   </ul><br>
   <a href="https://github.com/RFD-FHEM/RFFHEM/blob/dev-r33/test/install.md">Other instructions can be found here.</a>
 =end html
 
+
 =begin html_DE
+
  <a name="UnitTest"></a>
  <h3>UnitTest</h3><br>
   
@@ -367,9 +368,7 @@ sub UnitTest_mock_log3
 			developId		=> 'm',
 	 },<br>
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;SIGNALduino_IdList("x:$target","","","m9999");<br>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;is($Log3->called_count-$ref_called_count,$ref_called_count+1,"SIGNALduino_Log3 output increased");<br>
-  &nbsp;&nbsp;&nbsp;&nbsp;}<br>
-  &nbsp;&nbsp;);
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;is($Log3->called_count-$ref_called_count,$ref_called_count+1,"SIGNALduino_Log3 output increased");})
   </ul><br>
   <a href="https://github.com/RFD-FHEM/RFFHEM/blob/dev-r33/test/install.md">Eine weitere Anleitung finden Sie hier.</a>
 =end html_DE


### PR DESCRIPTION
- fix doc
- fix note on update FHEM
*** EN unittest: nonempty line after =begin html ignored
*** DE unittest: nonempty line after =begin html ignored

* **Please check if the PR fulfills these requirements**
- [X] commandref has been updated

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
no note on update FHEM
Example code adapted to regex test https://github.com/RFD-FHEM/RFFHEM/pull/309#issuecomment-442402648

* **What is the current behavior?** (You can also link to an open issue here)
note on update FHEM
*** EN unittest: nonempty line after =begin html ignored
*** DE unittest: nonempty line after =begin html ignored