### PR TITLE
unittest Module: Fix syntax check to support linebreaks in DEF

### DIFF
--- a/test/98_unittest.pm
+++ b/test/98_unittest.pm
@@ -32,7 +32,7 @@ sub UnitTest_Define() {
     my ($name,$type,$target,$cmd) = split('[ \t]+', $def,4);
 
 	#if (!$cmd || (not $cmd =~ m/^[(].*[)]$/g)) {
-	if (!$cmd || $cmd !~ m/(?:\(.*\)).*$/) {
+	if (!$cmd || $cmd !~ m/(?:\(.*\)).*$/s) {
 		my $msg = "wrong syntax: define <name> UnitTest <name of target device> (Test Code in Perl)";
 		Log3 undef, 2, $name.": ".$msg;
 		Log3 undef, 5, "$name: cmd was: $cmd";


### PR DESCRIPTION
fixed regex if DEF has linebreaks

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** 

Regex will ignore linebreaks and threat anything as a signle line.

* **What is the current behavior?** (You can also link to an open issue here)

Test can't be saved, if it has linebeaks  in DEF when using the codeditor via fhemweb

* **What is the new behavior (if this is a feature change)?**

Test can be saved, if it has linebeaks  in DEF when using the codeditor via fhemweb


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

can't write a test for the testunit itself :(