### PR TITLE
Update signalduino_protocols.hash

### DIFF
--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -47,7 +47,7 @@
 #
 ##### notice #### or #### info ############################################################################################################
 # Please use first unused id for new protocols
-# ID´s are currently unused: -
+# ID´s are currently unused: 14
 # ID´s need to be revised (preamble u): 5 | 6 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 31 | 36 | 40 | 52 | 56 | 59 | 63 | 78 | 87 | 88
 ###########################################################################################################################################
 # Please provide at least three messages for each new MU/MC/MS protocol and a URL of issue in GitHub or discussion in FHEM Forum
@@ -55,12 +55,12 @@
 ###########################################################################################################################################
 
 (
-	"0"	=>	# various weather sensors
+	"0"	=>	## various weather sensors
 					# CUL_TCM97001 Typ - Mebus
 					# MS;P0=-9298;P1=495;P2=-1980;P3=-4239;D=1012121312131313121313121312121212121212131212131312131212;CP=1;SP=0;R=223;O;m2;
 					# !!! some RAWMSG are also decode under ID 68 !!!
 		{
-			name						=> 'weather1',		# Logilink, NC, WS, TCM97001 etc.
+			name						=> 'weather1',	# Logilink, NC, WS, TCM97001 etc.
 			comment					=> 'Logilink, NC, WS, TCM97001 etc',
 			id							=> '0',
 			one							=> [1,-8],
@@ -76,7 +76,7 @@
 			length_max			=> '42',
 			paddingbits			=> '8',					# pad up to 8 bits, default is 4
 		},
-	"1"	=>	# ConradRSL
+	"1"	=>	## ConradRSL
 		{
 			name					=> 'ConradRSL',
 			id						=> '1',
@@ -92,7 +92,7 @@
 			length_min		=> '20',					# 23
 			length_max		=> '40',					# 24
 		},
-	"2"	=>	# Self build arduino sensor
+	"2"	=>	## Self build arduino sensor
 		{
 			name						=> 'AS, Self build arduino sensor',
 			comment					=> 'developModule. SD_AS module is only in github available',
@@ -110,11 +110,11 @@
 			length_max			=> '34',				# Don't know maximal lenth of a valid message
 			paddingbits			=> '8',					# pad up to 8 bits, default is 4
 		},
-	"3"	=>	# remote like WOFI Lamp
+	"3"	=>	## itv1 - remote like WOFI Lamp
 					# need more Device Infos / User Message
 		{
 			name						=> 'itv1',
-			comment         => 'example: remote for WOFI',
+			comment					=> 'example: remote for WOFI',
 			id							=> '3',
 			one							=> [3,-1],
 			zero						=> [1,-3],
@@ -128,27 +128,29 @@
 			length_min			=> '24',
 			length_max			=> '24',				# Don't know maximal lenth of a valid message
 		},
-	"3.1"	=>	# MS;P0=-11440;P1=-1121;P2=-416;P5=309;P6=1017;D=150516251515162516251625162516251515151516251625151;CP=5;SP=0;R=66;
+	"3.1"	=>	## itv1_sync40
+						# MS;P0=-11440;P1=-1121;P2=-416;P5=309;P6=1017;D=150516251515162516251625162516251515151516251625151;CP=5;SP=0;R=66;
 						# MS;P1=309;P2=-1130;P3=1011;P4=-429;P5=-11466;D=15123412121234123412141214121412141212123412341234;CP=1;SP=5;R=38;  Gruppentaste, siehe Kommentar in sub SIGNALduino_bit2itv1
 						# need more Device Infos / User Message
 		{
-			name						=> 'itv1_sync40',
-			comment					=> 'IT remote Control PAR 1000, ITS-150, AB440R',
-			id							=> '3',
-			one             => [3.5,-1],
-			zero						=> [1,-3.8],
-			float						=> [1,-1],	# fuer Gruppentaste (nur bei ITS-150,ITR-3500 und ITR-300), siehe Kommentar in sub SIGNALduino_bit2itv1
-			sync						=> [1,-44],
-			clockabs				=> -1,	# -1=auto	
-			format					=> 'twostate',	# not used now
-			preamble				=> 'i',			
-			clientmodule    => 'IT',
-			modulematch     => '^i......',
-			length_min      => '24',
-			length_max      => '24',		# Don't know maximal lenth of a valid message
-			postDemodulation => \&SIGNALduino_bit2itv1,
+			name							=> 'itv1_sync40',
+			comment						=> 'IT remote control PAR 1000, ITS-150, AB440R',
+			id								=> '3',
+			one								=> [3.5,-1],
+			zero							=> [1,-3.8],
+			float							=> [1,-1],			# fuer Gruppentaste (nur bei ITS-150,ITR-3500 und ITR-300), siehe Kommentar in sub SIGNALduino_bit2itv1
+			sync							=> [1,-44],
+			clockabs					=> -1,					# -1=auto	
+			format						=> 'twostate',	# not used now
+			preamble					=> 'i',			
+			clientmodule			=> 'IT',
+			modulematch				=> '^i......',
+			length_min				=> '24',
+			length_max				=> '24',				# Don't know maximal lenth of a valid message
+			postDemodulation	=> \&SIGNALduino_bit2itv1,
 		},
-	"4"	=>	# need more Device Infos / User Message
+	"4"	=>	## arctech2
+					# need more Device Infos / User Message
 		{
 			name						=> 'arctech2',
 			id							=> '4',
@@ -177,19 +179,19 @@
 					# A AUS:
 					# MU;P0=-1692;P1=132;P2=194;P4=355;P5=474;P7=-31892;D=010202040505050505050404040404040404040470;CP=4;R=27; 
 		{
-			name						=> 'unitec',
-			comment					=> 'model 6899/45108',
+			name						=> 'Unitec',
+			comment					=> 'remote control model 6899/45108',
 			id							=> '5',
-			one							=> [3,-1],		# ?
-			zero						=> [1,-3],		# ?
-			clockabs				=> 500,				# ?
+			one							=> [3,-1],			# ?
+			zero						=> [1,-3],			# ?
+			clockabs				=> 500,					# ?
 			developId				=> 'y',
 			format					=> 'twostate',
 			preamble				=> 'u5',
-			#clientmodule    => '',
-			#modulematch     => '',
-			length_min      => '24',			# ?
-			length_max      => '24',			# ?
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '24',				# ?
+			length_max			=> '24',				# ?
 		},
 	"6"	=>	## Eurochron Protocol
 		{
@@ -197,16 +199,16 @@
 			id						=> '6',
 			one						=> [1,-10],
 			zero					=> [1,-5],
-			sync					=> [1,-36],			# This special device has no sync
-			clockabs			=> 220,					# -1 = auto
-			format				=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble			=> 'u6#',				# Append to converted message
+			sync					=> [1,-36],				# This special device has no sync
+			clockabs			=> 220,						# -1 = auto
+			format				=> 'twostate',		# tristate can't be migrated from bin into hex!
+			preamble			=> 'u6#',					# Append to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '^u......',
 			length_min		=> '24',
-			#length_max		=> '36',				# missing
+			#length_max		=> '36',					# missing
 		},
-	"7"	=> ## weather sensors like EAS800z
+	"7"	=>	## weather sensors like EAS800z
 					# MS;P1=-3882;P2=504;P3=-957;P4=-1949;D=21232424232323242423232323232323232424232323242423242424242323232324232424;CP=2;SP=1;R=249;m=2;
 		{
 			name						=> 'weatherID7',
@@ -230,9 +232,9 @@
 			id							=> '8',
 			one							=> [1,-2],
 			zero						=> [2,-2],
-			#sync						=> [1,-8],			# 
+			#sync						=> [1,-8],			#
 			clockabs				=> 470,
-			format					=> 'pwm',				# 
+			format					=> 'pwm',				#
 			preamble				=> 'TX',				# prepend to converted message
 			clientmodule		=> 'CUL_TX',
 			modulematch			=> '^TX......',
@@ -251,7 +253,7 @@
 			#sync						=> [1,-8],			# 
 			clockabs				=> 480,					# -1 = auto undef=noclock
 			format					=> 'pwm',				# tristate can't be migrated from bin into hex!
-			preamble				=> 'P9#',				# prepend to converted message	
+			preamble				=> 'P9#',				# prepend to converted message
 			clientmodule		=> 'SD_WS09',
 			#modulematch		=> '^u9#.....',
 			length_min			=> '60',
@@ -272,7 +274,7 @@
 		},
 	"11"	=>	## Arduino Sensor
 		{
-			name						=> 'AS',	
+			name						=> 'AS',
 			id							=> '11',
 			clockrange			=> [380,425],						# min , max
 			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
@@ -281,7 +283,7 @@
 			modulematch			=> '^P2#.{7,8}',
 			length_min			=> '52',
 			length_max			=> '56',
-			method					=> \&SIGNALduino_AS # Call to process this message
+			method					=> \&SIGNALduino_AS			# Call to process this message
 		},
 	"12"	=>	## Hideki
 						# MC;LL=-1040;LH=904;SL=-542;SH=426;D=A8C233B53A3E0A0783;C=485;L=72;R=213;
@@ -299,7 +301,7 @@
 			method					=> \&SIGNALduino_Hideki,	# Call to process this message
 			#polarity				=> 'invert',
 		},
-	"13"	=>	## FLAMINGO  FA 21
+	"13"	=>	## FLAMINGO FA21
 						# https://github.com/RFD-FHEM/RFFHEM/issues/21
 						# https://github.com/RFD-FHEM/RFFHEM/issues/233
 						# MS;P0=-1413;P1=757;P2=-2779;P3=-16079;P4=8093;P5=-954;D=1345121210101212101210101012121012121210121210101010;CP=1;SP=3;R=33;O;
@@ -311,7 +313,7 @@
 			sync						=> [1,-20,10,-1],
 			clockabs				=> 800,
 			format					=> 'twostate',
-			preamble				=> 'P13#',				# prepend to converted message	
+			preamble				=> 'P13#',				# prepend to converted message
 			clientmodule		=> 'FLAMINGO',
 			#modulematch		=> 'P13#.*',
 			length_min			=> '24',
@@ -340,7 +342,8 @@
 			length_min			=> '24',
 			length_max			=> '24',
 		},
-	"13.2" => ## MS;P1=-2708;P2=796;P3=-1387;P4=-8477;P5=8136;P6=-904;D=2456212321212323232321212121212121212123212321212121;CP=2;SP=4;
+	"13.2"	=>	## LM-101LD Rauchm
+							# MS;P1=-2708;P2=796;P3=-1387;P4=-8477;P5=8136;P6=-904;D=2456212321212323232321212121212121212123212321212121;CP=2;SP=4;
 		{
 			name						=> 'LM-101LD Rauchm',
 			comment					=> 'Unitec Rauchmelder',
@@ -350,29 +353,29 @@
 			sync						=> [1,-11,10,-1.2],
 			clockabs				=> 790,
 			format					=> 'twostate',
-			preamble				=> 'P13#',	# prepend to converted message	
-			clientmodule    => 'FLAMINGO',
-			#modulematch     => '',
-			length_min      => '24',
-			length_max      => '24',
+			preamble				=> 'P13#',			# prepend to converted message
+			clientmodule		=> 'FLAMINGO',
+			#modulematch		=> '',
+			length_min			=> '24',
+			length_max			=> '24',
 		},
-	"14"	=>	## Heidemann HX BELL
-		{
-			name						=> 'Heidemann HX',
-			comment					=> 'Heidemann HX doorbell',
-			id							=> '14',
-			one							=> [1,-2],
-			zero						=> [1,-1],
-			#float					=> [-1,3],				# not full supported now, for later use
-			sync						=> [1,-14],
-			clockabs				=> 350,
-			format					=> 'twostate',
-			preamble				=> 'P14#',				# prepend to converted message
-			clientmodule		=> 'SD_BELL',
-			modulematch			=> '^P14#.*',
-			length_min			=> '12',
-			length_max			=> '20',
-		},
+	# "14"	=>	## Heidemann HX BELL
+		# {
+			# name						=> 'Heidemann HX',
+			# comment					=> 'Heidemann HX doorbell',
+			# id							=> '14',
+			# one							=> [1,-2],
+			# zero						=> [1,-1],
+			# #float					=> [-1,3],				# not full supported now, for later use
+			# sync						=> [1,-14],
+			# clockabs				=> 350,
+			# format					=> 'twostate',
+			# preamble				=> 'P14#',				# prepend to converted message
+			# clientmodule		=> 'SD_BELL',
+			# modulematch			=> '^P14#.*',
+			# length_min			=> '12',
+			# length_max			=> '20',
+		# },
 	"15"	=>	## TCM 234759
 		{
 			name						=> 'TCM 234759 Bell',
@@ -389,11 +392,11 @@
 			length_min			=> '10',
 			length_max			=> '20',
 		},
-	"16" => # Rohrmotor24 und andere Funk Rolladen / Markisen Motoren
-					# ! same definition how ID 72 !
-					# https://forum.fhem.de/index.php/topic,49523.0.html
-					# MU;P0=-1608;P1=-785;P2=288;P3=650;P4=-419;P5=4676;D=1212121213434212134213434212121343434212121213421213434212134345021213434213434342121212121343421213421343421212134343421212121342121343421213432;CP=2;
-					# MU;P0=-1562;P1=-411;P2=297;P3=-773;P4=668;P5=4754;D=1232341234141234141234141414123414123232341232341412323414150234123234123232323232323234123414123414123414141412341412323234123234141232341415023412323412323232323232323412341412341412341414141234141232323412323414123234142;CP=2;
+	"16"	=>	## Rohrmotor24 und andere Funk Rolladen / Markisen Motoren
+						# ! same definition how ID 72 !
+						# https://forum.fhem.de/index.php/topic,49523.0.html
+						# MU;P0=-1608;P1=-785;P2=288;P3=650;P4=-419;P5=4676;D=1212121213434212134213434212121343434212121213421213434212134345021213434213434342121212121343421213421343421212134343421212121342121343421213432;CP=2;
+						# MU;P0=-1562;P1=-411;P2=297;P3=-773;P4=668;P5=4754;D=1232341234141234141234141414123414123232341232341412323414150234123234123232323232323234123414123414123414141412341412323234123234141232341415023412323412323232323232323412341412341412341414141234141232323412323414123234142;CP=2;
 		{
 			name						=> 'Dooya shutter',
 			id							=> '16',
@@ -408,7 +411,8 @@
 			length_min			=> '39',
 			length_max			=> '40',
 		},
-	"17"	=> # need more Device Infos / User Message
+	"17"	=>	## arctech / intertechno
+						# need more Device Infos / User Message
 		{
 			name							=> 'arctech / intertechno',
 			id								=> '17',
@@ -419,7 +423,7 @@
 			sync							=> [1,-10],
 			float							=> [1,-1,1,-1],
 			end								=> [1,-40],
-			clockabs						=> -1,				# -1 = auto
+			clockabs					=> -1,					# -1 = auto
 			format						=> 'twostate',	# tristate can't be migrated from bin into hex!
 			preamble					=> 'i',					# Append to converted message
 			postamble					=> '00',				# Append to converted message
@@ -429,27 +433,27 @@
 			length_max				=> '34',				# Don't know maximal lenth of a valid message
 			postDemodulation	=> \&SIGNALduino_bit2Arctec,
 		},
-	"17.1"	=> # intertechno --> MU anstatt sonst MS (ID 17)
-			# MU;P0=344;P1=-1230;P2=-200;D=01020201020101020102020102010102010201020102010201020201020102010201020101020102020102010201020102010201010200;CP=0;R=0;
-			# MU;P0=346;P1=-1227;P2=-190;P4=-10224;P5=-2580;D=0102010102020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010102020102010201020104050201020102010102020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010102020102010201020;CP=0;R=0;
-			# MU;P0=351;P1=-1220;P2=-185;D=01 0201 0102 020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010201020102010201020100;CP=0;R=0;
-			# MU;P0=355;P1=-189;P2=-1222;P3=-10252;P4=-2604;D=01020201010201020201020101020102020102010201020102010201010201020102010201020201020101020102010201020102010201020 304 0102 01020102020101020201010201020201020101020102020102010201020102010201010201020102010201020201020101020102010201020102010201020 304 01020;CP=0;R=0;
-			# https://www.sweetpi.de/blog/329/ein-ueberblick-ueber-433mhz-funksteckdosen-und-deren-protokolle
+	"17.1"	=>	## intertechno --> MU anstatt sonst MS (ID 17)
+							# MU;P0=344;P1=-1230;P2=-200;D=01020201020101020102020102010102010201020102010201020201020102010201020101020102020102010201020102010201010200;CP=0;R=0;
+							# MU;P0=346;P1=-1227;P2=-190;P4=-10224;P5=-2580;D=0102010102020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010102020102010201020104050201020102010102020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010102020102010201020;CP=0;R=0;
+							# MU;P0=351;P1=-1220;P2=-185;D=01 0201 0102 020101020201020101020102020102010102010201020102010201020201020102010201020101020102020102010201020102010201020100;CP=0;R=0;
+							# MU;P0=355;P1=-189;P2=-1222;P3=-10252;P4=-2604;D=01020201010201020201020101020102020102010201020102010201010201020102010201020201020101020102010201020102010201020 304 0102 01020102020101020201010201020201020101020102020102010201020102010201010201020102010201020201020101020102010201020102010201020 304 01020;CP=0;R=0;
+							# https://www.sweetpi.de/blog/329/ein-ueberblick-ueber-433mhz-funksteckdosen-und-deren-protokolle
 		{
-			name						=> 'intertechno',
-			comment					=> 'PIR-1000 | ITT-1500',
-			id							=> '17.1',
-			one							=> [1,-5,1,-1],
-			zero						=> [1,-1,1,-5],
-			clockabs				=> 230,			# -1 = auto
-			format					=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble				=> 'i',			# Append to converted message
-			postamble				=> '00',		# Append to converted message
-			clientmodule    => 'IT',
-			modulematch     => '^i......',
-			length_min      => '32',
-			length_max     	=> '34',		# Don't know maximal lenth of a valid message
-			postDemodulation => \&SIGNALduino_bit2Arctec,
+			name							=> 'intertechno',
+			comment						=> 'PIR-1000 | ITT-1500',
+			id								=> '17.1',
+			one								=> [1,-5,1,-1],
+			zero							=> [1,-1,1,-5],
+			clockabs					=> 230,					# -1 = auto
+			format						=> 'twostate',	# tristate can't be migrated from bin into hex!
+			preamble					=> 'i',					# Append to converted message
+			postamble					=> '00',				# Append to converted message
+			clientmodule			=> 'IT',
+			modulematch				=> '^i......',
+			length_min				=> '32',
+			length_max				=> '34',				# Don't know maximal lenth of a valid message
+			postDemodulation	=> \&SIGNALduino_bit2Arctec,
 		},
 	"18"	=>	## Oregon Scientific v1
 						# MC;LL=-2721;LH=3139;SL=-1246;SH=1677;D=1A51FF47;C=1463;L=32;R=12;
@@ -466,14 +470,14 @@
 			polarity				=> 'invert',						# invert bits
 			method					=> \&SIGNALduino_OSV1		# Call to process this message
 		},
-	"19" => # minify Funksteckdose
-					# https://github.com/RFD-FHEM/RFFHEM/issues/114
-					# MU;P0=293;P1=-887;P2=-312;P6=-1900;P7=872;D=6727272010101720172720101720172010172727272720;CP=0;
-					# MU;P0=9078;P1=-308;P2=180;P3=-835;P4=881;P5=309;P6=-1316;D=0123414141535353415341415353415341535341414141415603;CP=5;
+	"19"	=>	## minify Funksteckdose
+						# https://github.com/RFD-FHEM/RFFHEM/issues/114
+						# MU;P0=293;P1=-887;P2=-312;P6=-1900;P7=872;D=6727272010101720172720101720172010172727272720;CP=0;
+						# MU;P0=9078;P1=-308;P2=180;P3=-835;P4=881;P5=309;P6=-1316;D=0123414141535353415341415353415341535341414141415603;CP=5;
 		{
 			name					=> 'minify',
-			comment				=> 'remote RC202',
-			id          	=> '19',
+			comment				=> 'remote control RC202',
+			id						=> '19',
 			one						=> [3,-1],
 			zero					=> [1,-3],
 			clockabs			=> 300,
@@ -484,7 +488,7 @@
 			length_min		=> '19',
 			length_max		=> '23',					# not confirmed, length one more as MU Message
 		},
-	"20"	=>	# Livolo
+	"20"	=>	## Livolo
 						# https://github.com/RFD-FHEM/RFFHEM/issues/29
 						# MU;P0=-195;P1=151;P2=475;P3=-333;D=0101010101 02 01010101010101310101310101010101310101 02 01010101010101010101010101010101010101 02 01010101010101010101010101010101010101 02 010101010101013101013101;CP=1;
 						#
@@ -494,8 +498,8 @@
 						#             _____________                 ___                 _______
 						# Start bit: |             |___|    bit 0: |   |___|    bit 1: |       |___|
 		{
-			name					=> 'livolo',
-			id          	=> '20',
+			name					=> 'Livolo',
+			id						=> '20',
 			one						=> [3],
 			zero					=> [1],
 			start					=> [5],
@@ -508,14 +512,14 @@
 			#length_max		=> '',						# missing
 			filterfunc		=> 'SIGNALduino_filterSign',
 		},
-	"21"	=>	# Einhell Garagentor
+	"21"	=>	## Einhell Garagentor
 						# https://forum.fhem.de/index.php?topic=42373.0 | user have no RAWMSG
 						# static adress: Bit 1-28 | channel remote Bit 29-32 | repeats 31 | pause 20 ms
 						# Channelvalues dez
 						# 1 left 1x kurz | 2 left 2x kurz | 3 left 3x kurz | 5 right 1x kurz | 6 right 2x kurz | 7 right 3x kurz ... gedrückt
 		{
 			name						=> 'Einhell Garagedoor',
-			comment         => 'remote ISC HS 434/6',
+			comment					=> 'remote control ISC HS 434/6',
 			id							=> '21',
 			one							=> [-3,1],
 			zero						=> [-1,3],
@@ -524,32 +528,32 @@
 			clockabs				=> 400,					#ca 400us
 			format					=> 'twostate',
 			preamble				=> 'u21#',			# prepend to converted message
-			#clientmodule   => '',
-			#modulematch    => '',
-			length_min      => '32',
-			length_max      => '32',
-			paddingbits     => '1',					# This will disable padding
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '32',
+			length_max			=> '32',
+			paddingbits			=> '1',					# This will disable padding
 		},
-	"22" => ## HAMULiGHT LED Trafo
-					# https://forum.fhem.de/index.php?topic=89301.0
-					# MU;P0=-589;P1=209;P2=-336;P3=32001;P4=-204;P5=1194;P6=-1200;P7=602;D=0123414145610747474101010101074741010747410741074101010101074741010741074741414141456107474741010101010747410107474107410741010101010747410107410747414141414561074747410101010107474101074741074107410101010107474101074107474141414145610747474101010101074;CP=1;R=25;
-					# MU;P0=204;P1=-596;P2=598;P3=-206;P4=1199;P5=-1197;D=0123230123012301010101012323010123012323030303034501232323010101010123230101232301230123010101010123230101230123230303030345012323230101010101232301012323012301230101010101232301012301232303030303450123232301010101012323010123230123012301010101012323010;CP=0;R=25;
-			{
-				name						=> 'HAMULiGHT',
-				comment					=> 'remote LED Transformator',
-				id							=> '22',
-				one							=> [1,-3],
-				zero						=> [3,-1],
-				start						=> [6,-6],
-				clockabs				=> 200,						# ca 200us
-				format					=> 'twostate',
-				preamble				=> 'u22#',				# prepend to converted message
-				#clientmodule    => '',
-				#modulematch     => '',
-				length_min      => '32',
-				length_max      => '32',
-			},
-	"23" => # Pearl Sensor
+	"22"	=>	## HAMULiGHT LED Trafo
+						# https://forum.fhem.de/index.php?topic=89301.0
+						# MU;P0=-589;P1=209;P2=-336;P3=32001;P4=-204;P5=1194;P6=-1200;P7=602;D=0123414145610747474101010101074741010747410741074101010101074741010741074741414141456107474741010101010747410107474107410741010101010747410107410747414141414561074747410101010107474101074741074107410101010107474101074107474141414145610747474101010101074;CP=1;R=25;
+						# MU;P0=204;P1=-596;P2=598;P3=-206;P4=1199;P5=-1197;D=0123230123012301010101012323010123012323030303034501232323010101010123230101232301230123010101010123230101230123230303030345012323230101010101232301012323012301230101010101232301012301232303030303450123232301010101012323010123230123012301010101012323010;CP=0;R=25;
+		{
+			name						=> 'HAMULiGHT',
+			comment					=> 'remote control for LED Transformator',
+			id							=> '22',
+			one							=> [1,-3],
+			zero						=> [3,-1],
+			start						=> [6,-6],
+			clockabs				=> 200,					# ca 200us
+			format					=> 'twostate',
+			preamble				=> 'u22#',			# prepend to converted message
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '32',
+			length_max			=> '32',
+		},
+	"23"	=>	## Pearl Sensor
 		{
 			name					=> 'perl unknown',
 			id						=> '23',
@@ -564,12 +568,12 @@
 			length_min		=> '36',
 			length_max		=> '44',
 		},
-	"24" =>	# visivon
-					# https://github.com/RFD-FHEM/RFFHEM/issues/39
-					# MU;P0=132;P1=500;P2=-233;P3=-598;P4=-980;P5=4526;D=012120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030;CP=0;O;
+	"24"	=>	## visivon
+						# https://github.com/RFD-FHEM/RFFHEM/issues/39
+						# MU;P0=132;P1=500;P2=-233;P3=-598;P4=-980;P5=4526;D=012120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030;CP=0;O;
 		{
 			name					=> 'visivon remote',
-			id          	=> '24',
+			id						=> '24',
 			one						=> [3,-2],
 			zero					=> [1,-5],
 			#one					=> [3,-2],
@@ -583,9 +587,9 @@
 			length_min		=> '54',
 			length_max		=> '58',
 		},
-	"25" => # LES remote for led lamp
-					# https://github.com/RFD-FHEM/RFFHEM/issues/40
-					# MS;P0=-376;P1=697;P2=-726;P3=322;P4=-13188;P5=-15982;D=3530123010101230123230123010101010101232301230123234301230101012301232301230101010101012323012301232;CP=3;SP=5;O;
+	"25"	=>	## LES remote for led lamp
+						# https://github.com/RFD-FHEM/RFFHEM/issues/40
+						# MS;P0=-376;P1=697;P2=-726;P3=322;P4=-13188;P5=-15982;D=3530123010101230123230123010101010101232301230123234301230101012301232301230101010101012323012301232;CP=3;SP=5;O;
 		{
 			name					=> 'les led remote',
 			id						=> '25',
@@ -600,9 +604,9 @@
 			length_min		=> '24',
 			length_max		=> '50',					# message has only 24 bit, but we get more than one message, calculation has to be corrected
 		},
-	"26" => # some remote code send by flamingo style remote controls
-					# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
-					# MU;P0=1086;P1=-433;P2=327;P3=-1194;P4=-2318;P5=2988;D=01012323010123010101230123012323232323010101232324010123230101230101012301230123232323230101012323240101232301012301010123012301232323232301010123232401012323010123010101230123012323232323010101232353;CP=2;
+	"26"	=>	## some remote code send by flamingo style remote controls
+						# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
+						# MU;P0=1086;P1=-433;P2=327;P3=-1194;P4=-2318;P5=2988;D=01012323010123010101230123012323232323010101232324010123230101230101012301230123232323230101012323240101232301012301010123012301232323232301010123232401012323010123010101230123012323232323010101232353;CP=2;
 		{
 			name					=> 'remote26',
 			id						=> '26',
@@ -618,9 +622,9 @@
 			length_min		=> '24',
 			length_max		=> '24',					# message has only 24 bit, but we get more than one message, calculation has to be corrected
 		},
-	"27" => # some remote code, send by flamingo style remote controls
-					# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
-					# MU;P0=963;P1=-559;P2=393;P3=-1134;P4=2990;P5=-7172;D=01012323010123010101230123012323232323010101232345010123230101230101012301230123232323230101012323450101232301012301010123012301232323232301010123234501012323010123010101230123012323232323010101232323;CP=2;
+	"27"	=>	## some remote code, send by flamingo style remote controls
+						# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
+						# MU;P0=963;P1=-559;P2=393;P3=-1134;P4=2990;P5=-7172;D=01012323010123010101230123012323232323010101232345010123230101230101012301230123232323230101012323450101232301012301010123012301232323232301010123234501012323010123010101230123012323232323010101232323;CP=2;
 		{
 			name						=> 'remote27',
 			id							=> '27',
@@ -635,7 +639,7 @@
 			length_min			=> '24',
 			length_max			=> '24',
 		},
-	"28" => # some remote code, send by aldi IC Ledspots
+	"28"	=>	## some remote code, send by aldi IC Ledspots
 		{
 			name						=> 'IC Ledspot',
 			id							=> '28',
@@ -650,12 +654,12 @@
 			length_min			=> '8',
 			length_max			=> '8',
 		},
-	"29" => # example remote control with HT12E chip
-					# MU;P0=250;P1=-492;P2=166;P3=-255;P4=491;P5=-8588;D=052121212121234121212121234521212121212341212121212345212121212123412121212123452121212121234121212121234;CP=0;
-					# https://forum.fhem.de/index.php/topic,58397.960.html
+	"29"	=>	## example remote control with HT12E chip
+						# MU;P0=250;P1=-492;P2=166;P3=-255;P4=491;P5=-8588;D=052121212121234121212121234521212121212341212121212345212121212123412121212123452121212121234121212121234;CP=0;
+						# https://forum.fhem.de/index.php/topic,58397.960.html
 		{
-			name						=> 'HT12e remote',
-			comment					=> 'Remote control for example Westinghouse airfan with five Buttons (developModule SD_UT is only in github available)',
+			name						=> 'HT12e',
+			comment					=> 'remote control for example Westinghouse airfan with 5 buttons',
 			id							=> '29',
 			one							=> [-2,1],
 			zero						=> [-1,2],
@@ -668,13 +672,13 @@
 			length_min			=> '12',
 			length_max			=> '12',
 		},
-	 "30" => 	# a unitec remote door reed switch
+	"30"	=>	## a unitec remote door reed switch
 						# https://forum.fhem.de/index.php?topic=43346.0
 						# MU;P0=-10026;P1=-924;P2=309;P3=-688;P4=-361;P5=637;D=123245453245324532453245320232454532453245324532453202324545324532453245324532023245453245324532453245320232454532453245324532453202324545324532453245324532023245453245324532453245320232454532453245324532453202324545324532453245324532023240;CP=2;O;
 						# MU;P0=307;P1=-10027;P2=-691;P3=-365;P4=635;D=0102034342034203420342034201020343420342034203420342010203434203420342034203420102034342034203420342034201020343420342034203420342010203434203420342034203420102034342034203420342034201;CP=0;
 		{
 			name					=> 'diverse',
-			comment				=> 'unitec remote door reed switch 47031 (developModule SD_UT module is only in github available)',
+			comment				=> 'remote control unitec | door reed switch 47031',
 			id						=> '30',
 			one						=> [-2,1],
 			zero					=> [-1,2],
@@ -687,17 +691,17 @@
 			length_min		=> '12',
 			length_max		=> '12',				# message has only 10 bit but is paddet to 12
 		},
-	"31" => # Pollin Isotronik - 12 Tasten remote
-			# https://github.com/RFD-FHEM/RFFHEM/issues/44
-			# OLD
-			# MU;P0=-32001;P1=1208;P2=-682;P3=-1324;P4=570;P5=-15617;D=12121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213405;CP=1;
-			# NEW
-			# MU;P0=-9584;P1=592;P2=-665;P3=1223;P4=-1311;D=01234141412341412341414123232323412323234;CP=1;R=0;
-			# MU;P0=-12724;P1=597;P2=-667;P3=1253;P4=-1331;D=01234141412341412341414123232323232323232;CP=1;R=0;
-			# MU;P0=-9588;P1=600;P2=-664;P3=1254;P4=-1325;D=01234141412341412341414123232323232323232;CP=1;R=0;
+	"31"	=>	## Pollin Isotronik - 12 Tasten remote
+						# https://github.com/RFD-FHEM/RFFHEM/issues/44
+						# OLD
+						# MU;P0=-32001;P1=1208;P2=-682;P3=-1324;P4=570;P5=-15617;D=12121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213405;CP=1;
+						# NEW
+						# MU;P0=-9584;P1=592;P2=-665;P3=1223;P4=-1311;D=01234141412341412341414123232323412323234;CP=1;R=0;
+						# MU;P0=-12724;P1=597;P2=-667;P3=1253;P4=-1331;D=01234141412341412341414123232323232323232;CP=1;R=0;
+						# MU;P0=-9588;P1=600;P2=-664;P3=1254;P4=-1325;D=01234141412341412341414123232323232323232;CP=1;R=0;
 		{
 			name					=> 'Pollin Isotronik',
-			comment				=> 'remote',
+			comment				=> 'remote control with 12 buttons',
 			id						=> '31',
 			one						=> [-1,2],
 			zero					=> [-2,1],
@@ -710,16 +714,16 @@
 			length_min		=> '19',
 			length_max		=> '20',
 		},
-	"32" => # FreeTec PE-6946 -> http://www.free-tec.de/Funkklingel-mit-Voic-PE-6946-919.shtml
-			# OLD
-			# https://github.com/RFD-FHEM/RFFHEM/issues/49
-			# MS;P0=-266;P1=160;P3=-690;P4=580;P5=-6628;D=15131313401340134013401313404040404040404040404040;CP=1;SP=5;O;
-			# NEW
-			# https://github.com/RFD-FHEM/RFFHEM/issues/315
-			# MU;P0=-6676;P1=578;P2=-278;P4=-680;P5=176;P6=-184;D=541654165412545412121212121212121212121250545454125412541254125454121212121212121212121212;CP=1;R=0;
-			# MU;P0=146;P1=245;P3=571;P4=-708;P5=-284;P7=-6689;D=14351435143514143535353535353535353535350704040435043504350435040435353535353535353535353507040404350435043504350404353535353535353535353535070404043504350435043504043535353535353535353535350704040435043504350435040435353535353535353535353507040404350435;CP=3;R=0;O;
-			# MU;P0=-6680;P1=162;P2=-298;P4=253;P5=-699;P6=555;D=45624562456245456262626262626262626262621015151562156215621562151562626262626262626262626210151515621562156215621515626262626262626262626262;CP=6;R=0;
-		{   
+	"32"	=>	## FreeTec PE-6946 -> http://www.free-tec.de/Funkklingel-mit-Voic-PE-6946-919.shtml
+						# OLD
+						# https://github.com/RFD-FHEM/RFFHEM/issues/49
+						# MS;P0=-266;P1=160;P3=-690;P4=580;P5=-6628;D=15131313401340134013401313404040404040404040404040;CP=1;SP=5;O;
+						# NEW
+						# https://github.com/RFD-FHEM/RFFHEM/issues/315
+						# MU;P0=-6676;P1=578;P2=-278;P4=-680;P5=176;P6=-184;D=541654165412545412121212121212121212121250545454125412541254125454121212121212121212121212;CP=1;R=0;
+						# MU;P0=146;P1=245;P3=571;P4=-708;P5=-284;P7=-6689;D=14351435143514143535353535353535353535350704040435043504350435040435353535353535353535353507040404350435043504350404353535353535353535353535070404043504350435043504043535353535353535353535350704040435043504350435040435353535353535353535353507040404350435;CP=3;R=0;O;
+						# MU;P0=-6680;P1=162;P2=-298;P4=253;P5=-699;P6=555;D=45624562456245456262626262626262626262621015151562156215621562151562626262626262626262626210151515621562156215621515626262626262626262626262;CP=6;R=0;
+		{
 			name						=> 'freetec 6946',
 			comment					=> 'Doorbell FreeTec PE-6946',
 			id							=> '32',
@@ -735,7 +739,7 @@
 			length_min			=> '24',
 			length_max			=> '24',
 		},
-	"33"	=>	# Thermo-/Hygrosensor S014, renkforce E0001PA, Conrad S522, TX-EZ6 (Weatherstation TZS First Austria)
+	"33"	=>	## Thermo-/Hygrosensor S014, renkforce E0001PA, Conrad S522, TX-EZ6 (Weatherstation TZS First Austria)
 						# https://forum.fhem.de/index.php?topic=35844.0
 						# MS;P0=-7871;P2=-1960;P3=578;P4=-3954;D=030323232323434343434323232323234343434323234343234343234343232323432323232323232343234;CP=3;SP=0;R=0;m=0;
 						# sensor id=62, channel=1, temp=21.1, hum=76, bat=ok
@@ -756,14 +760,14 @@
 			length_min		=> '42',
 			length_max		=> '44',
 		},
-	"34"	=>	# QUIGG GT-7000 Funk-Steckdosendimmer | transmitter DMV-7000 - receiver DMV-7009AS
+	"34"	=>	## QUIGG GT-7000 Funk-Steckdosendimmer | transmitter DMV-7000 - receiver DMV-7009AS
 						# https://github.com/RFD-FHEM/RFFHEM/issues/195 | https://forum.fhem.de/index.php/topic,38831.msg361341.html#msg361341
 						# MU;P0=-5284;P1=583;P2=-681;P3=1216;P4=-1319;D=012341412323232341412341412323234123232341;CP=1;R=16; | MU;P0=-9812;P1=589;P2=-671;P3=1261;P4=-1320;D=012341412323232341412341412323232323232323;CP=3;R=19;
 						# MU;P0=-9832;P1=577;P2=-670;P3=1219;P4=-1331;D=012341412323232341412341414123234123234141;CP=1;R=16; | MU;P0=-8816;P1=594;P2=-662;P3=1263;P4=-1330;D=012341412323232341412341414123232323234123;CP=1;R=16;
 						# MU;P0=-677;P1=581;P2=1250;P3=-1319;D=010231310202020231310231310231023102020202;CP=1;R=18; | MU;P0=-29120;P1=603;P2=-666;P3=1235;P4=-1307;D=012341412323232341412341412341232323232341;CP=1;R=16;
 		{
 			name					=> 'QUIGG_GT-7000',
-			comment				=> 'remote QUIGG DMV-7000',
+			comment				=> 'remote control DMV-7000',
 			id						=> '34',
 			one						=> [-1,2],
 			zero					=> [-2,1],
@@ -777,8 +781,8 @@
 			length_min		=> '20',
 			length_max		=> '20',
 		},
-	"35" => # Homeeasy
-					# MS;P0=907;P1=-376;P2=266;P3=-1001;P6=-4860;D=2601010123230123012323230101012301230101010101230123012301;CP=2;SP=6;
+	"35"	=>	## Homeeasy
+						# MS;P0=907;P1=-376;P2=266;P3=-1001;P6=-4860;D=2601010123230123012323230101012301230101010101230123012301;CP=2;SP=6;
 		{
 			name							=> 'HE800',
 			comment						=> 'Homeeasy',
@@ -796,7 +800,7 @@
 			length_max				=> '40',
 			postDemodulation	=> \&SIGNALduino_HE800,
 		},
-	"36" =>
+	"36"	=>	## socket36
 		{
 			name						=> 'socket36',
 			id							=> '36',
@@ -836,7 +840,7 @@
 						# MS;P1=367;P2=-2077;P4=-9415;P5=-4014;D=141515151515151515121512121212121212121212121212121212121212121212;CP=1;SP=4;O;
 		{
 			name						=> 'weather38',
-			id          		=> '38',
+			id							=> '38',
 			one							=> [1,-10],
 			zero						=> [1,-5],
 			sync						=> [1,-25],
@@ -946,7 +950,7 @@
 			#msgOutro			=> 'SR;P0=-30415;D=0;',
 			frequency			=> '10AB85550A',
 		},
-	"44" => ## Bresser Temeo Trend
+	"44"	=>	## Bresser Temeo Trend
 		{
 			name					=> 'BresserTemeo',
 			id						=> '44',
@@ -957,8 +961,8 @@
 			preamble			=> 'W44#',
 			clientmodule	=> 'SD_WS',
 			modulematch		=> '^W44#[A-F0-9]{18}',
-			length_min 		=> '64',
-			length_max 		=> '72',
+			length_min		=> '64',
+			length_max		=> '72',
 		},
 	"44.1"	=>	## Bresser Temeo Trend
 		{
@@ -974,7 +978,7 @@
 			length_min		=> '64',
 			length_max		=> '72',
 		},
-	"45"	=>	#  Revolt 
+	"45"	=>	## Revolt 
 						#	MU;P0=-8320;P1=9972;P2=-376;P3=117;P4=-251;P5=232;D=012345434345434345454545434345454545454543454343434343434343434343434543434345434343434545434345434343434343454343454545454345434343454345434343434343434345454543434343434345434345454543454343434543454345434545;CP=3;R=2
 		{
 			name							=> 'Revolt',
@@ -989,7 +993,7 @@
 			length_min				=> '84',
 			length_max				=> '120',
 			postDemodulation	=> sub {	my ($name, @bit_msg) = @_;	my @new_bitmsg = splice @bit_msg, 0,88;	return 1,@new_bitmsg; },
-		},    
+		},
 	"46"	=>	## Berner Garagentorantrieb GA401
 						# remote TEDSEN SKX1MD 433.92 MHz - 1 button | settings via 9 switch on battery compartment
 						# compatible with doors: BERNER SKX1MD, ELKA SKX1MD, TEDSEN SKX1LC, TEDSEN SKX1
@@ -1000,7 +1004,7 @@
 						# MU;P0=-1943;P1=1966;P2=-327;P3=247;P5=-15810;D=01230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230;CP=1;
 		{
 			name						=> 'Berner Garagedoor GA401',
-			comment					=> 'remote TEDSEN SKX1MD',
+			comment					=> 'remote control TEDSEN SKX1MD',
 			id							=> '46',
 			one							=> [1,-8],
 			zero						=> [8,-1],
@@ -1013,7 +1017,7 @@
 			length_min			=> '16',
 			length_max			=> '18',
 		},
-	"47"	=>	## maverick
+	"47"	=>	## Maverick
 						# MC;LL=-507;LH=490;SL=-258;SH=239;D=AA9995599599A959996699A969;C=248;L=104;
 		{
 			name						=> 'Maverick protocol',
@@ -1052,6 +1056,7 @@
 						# MU;P0=-563;P1=479;P2=991;P3=-423;P4=361;P5=-1053;P6=3008;P7=-7110;D=2345454523452323454523452323452323452323454545456720151515201520201515201520201520201520201515151567201515152015202015152015202015202015202015151515672015151520152020151520152020152020152020151515156720151515201520201515201520201520201520201515151;CP=1;R=21;
 		{
 			name						=> 'QUIGG_GT-9000',
+			comment					=> 'remote control',
 			id							=> '49',
 			clockabs				=> 400,
 			one							=> [2,-1.2],
@@ -1081,7 +1086,7 @@
 			length_min			=> '47',
 			length_max			=> '48',
 		},
-	"51"	=>	# weather sensors
+	"51"	=>	## weather sensors
 						# MS;P0=-16046;P1=552;P2=-1039;P3=983;P5=-7907;P6=-1841;P7=-4129;D=15161716171616161717171716161616161617161717171717171617171617161716161616161616171032323232;CP=1;SP=5;O;
 						# https://github.com/RFD-FHEM/RFFHEM/issues/118
 		{
@@ -1092,9 +1097,9 @@
 			zero						=> [1,-4],
 			sync						=> [1,-13],
 			clockabs				=> '560',
-			format					=> 'twostate',	# not used now
-			preamble				=> 'W51#',			# prepend to converted message
-			postamble				=> '',					# Append to converted message
+			format					=> 'twostate',		# not used now
+			preamble				=> 'W51#',				# prepend to converted message
+			postamble				=> '',						# Append to converted message
 			clientmodule		=> 'SD_WS',
 			modulematch			=> '^W51#.*',
 			length_min			=> '40',
@@ -1116,9 +1121,10 @@
 			method					=> \&SIGNALduino_OSPIR,		# Call to process this message
 			polarity				=> 'invert',
 		},
-	"55"	=> ## QUIGG GT-1000
+	"55"	=>	## QUIGG GT-1000
 		{
 			name						=> 'QUIGG_GT-1000',
+			comment					=> 'remote control',
 			id							=> '55',
 			clockabs				=> 300,
 			zero						=> [1,-4],
@@ -1131,7 +1137,7 @@
 			length_min			=> '24',
 			length_max			=> '24',
 		},
-	"56" => ##  Celexon
+	"56"	=>	## Celexon
 		{
 			name						=> 'Celexon',
 			id							=> '56',
@@ -1146,14 +1152,14 @@
 			length_min			=> '56',
 			length_max			=> '68',
 		},
-	"57" =>	## m-e doorbell fuer FG- und Basic-Serie
-			# https://forum.fhem.de/index.php/topic,64251.0.html
-			# MC;LL=-653;LH=665;SL=-317;SH=348;D=D55B58;C=330;L=21;
-			# MC;LL=-654;LH=678;SL=-314;SH=351;D=D55B58;C=332;L=21;
-			# MC;LL=-653;LH=679;SL=-310;SH=351;D=D55B58;C=332;L=21;
+	"57"	=>	## m-e doorbell fuer FG- und Basic-Serie
+						# https://forum.fhem.de/index.php/topic,64251.0.html
+						# MC;LL=-653;LH=665;SL=-317;SH=348;D=D55B58;C=330;L=21;
+						# MC;LL=-654;LH=678;SL=-314;SH=351;D=D55B58;C=332;L=21;
+						# MC;LL=-653;LH=679;SL=-310;SH=351;D=D55B58;C=332;L=21;
 		{
 			name						=> 'm-e',
-			comment					=> 'radio gong transmitter for FG- and Basic-Serie ',
+			comment					=> 'radio gong transmitter for FG- and Basic-Serie',
 			id							=> '57',
 			clockrange			=> [300,360],						# min , max
 			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
@@ -1167,7 +1173,7 @@
 		},
 	"58"	=>	## tfa 30.3208.0 
 		{
-			name						=> 'tfa 30.3208.0 ',
+			name						=> 'tfa 30.3208.0',
 			id							=> '58',
 			clockrange			=> [460,520],			# min , max
 			format					=> 'manchester',	# tristate can't be migrated from bin into hex!
@@ -1179,12 +1185,13 @@
 			method					=> \&SIGNALduino_MCTFA, # Call to process this message
 			polarity				=> 'invert',
 		},
-	"59"	=>	##  AK-HD-4 remote | 4 Buttons
+	"59"	=>	## AK-HD-4 remote | 4 Buttons
 						# https://github.com/RFD-FHEM/RFFHEM/issues/133
 						# MU;P0=819;P1=-919;P2=234;P3=-320;P4=8602;P6=156;D=01230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034123030123030123030301212301230123030303030123030341230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034163;CP=0;O;
 						# MU;P0=-334;P2=8581;P3=237;P4=-516;P5=782;P6=-883;D=23456305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505630505630505056363056305630505050505630505026305056305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505;CP=5;O;
 		{
 			name						=> 'AK-HD-4',
+			comment					=> 'remote control with 4 buttons',
 			id							=> '59',
 			clockabs				=> 230,
 			zero						=> [-4,1],
@@ -1222,19 +1229,19 @@
 			length_max					=> '82',
 			postDemodulation		=> \&SIGNALduino_postDemo_WS2000,
 		},
-	"61" =>	## ELV FS10
-					# tested transmitter:   FS10-S8, FS10-S4, FS10-ZE
-					# tested receiver:      FS10-ST, FS10-MS, WS3000-TV, PC-Wettersensor-Empfaenger
-					# sends 2 messages with 43 or 48 bits in distance of 100 mS (on/off) , last bit 1 is missing
-					# sends x messages with 43 or 48 bits in distance of 200 mS (dimm) , repeats second message
-					# MU;P0=1776;P1=-410;P2=383;P3=-820;D=01212121212121212121212123212121232323212323232121212323232121212321212123232123212120;CP=2;R=74;
-					#  __         __
-					# |  |__     |  |____
-					#  Bit 0      Bit 1
-					# kurz 400 mikroSek / lang 800 mikroSek / gesamt 800 mikroSek = 0, gesamt 1200 mikroSek = 1 - Sollzeiten 
+	"61"	=>	## ELV FS10
+						# tested transmitter:   FS10-S8, FS10-S4, FS10-ZE
+						# tested receiver:      FS10-ST, FS10-MS, WS3000-TV, PC-Wettersensor-Empfaenger
+						# sends 2 messages with 43 or 48 bits in distance of 100 mS (on/off) , last bit 1 is missing
+						# sends x messages with 43 or 48 bits in distance of 200 mS (dimm) , repeats second message
+						# MU;P0=1776;P1=-410;P2=383;P3=-820;D=01212121212121212121212123212121232323212323232121212323232121212321212123232123212120;CP=2;R=74;
+						#  __         __
+						# |  |__     |  |____
+						#  Bit 0      Bit 1
+						# kurz 400 mikroSek / lang 800 mikroSek / gesamt 800 mikroSek = 0, gesamt 1200 mikroSek = 1 - Sollzeiten 
 		{
 			name					=> 'FS10',
-			comment				=> 'Remote Control (434Mhz)',
+			comment				=> 'remote control (434Mhz)',
 			id						=> '61',
 			one						=> [1,-2],
 			zero					=> [1,-1],
@@ -1248,8 +1255,8 @@
 			length_min		=> '38',				# eigentlich 41 oder 46 (Pruefsumme nicht bei allen)
 			length_max		=> '48',				# eigentlich 46
 		},
-	"62" => ## Clarus_Switch  
-					# MU;P0=-5893;P4=-634;P5=498;P6=-257;P7=116;D=45656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674565656747474747474565670745674747474745674567456745656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674567;CP=7;O;		
+	"62"	=>	## Clarus_Switch
+						# MU;P0=-5893;P4=-634;P5=498;P6=-257;P7=116;D=45656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674565656747474747474565670745674747474745674567456745656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674567;CP=7;O;		
 		{
 			name					=> 'Clarus_Switch',
 			id						=> '62',
@@ -1263,10 +1270,10 @@
 			length_min		=> '24',
 			length_max		=> '24',
 		},
-	"63" => ## Warema MU
-					# https://forum.fhem.de/index.php/topic,38831.msg395978/topicseen.html#msg395978 | https://www.mikrocontroller.net/topic/264063
-					# MU;P0=-2988;P1=1762;P2=-1781;P3=-902;P4=871;P5=6762;P6=5012;D=0121342434343434352434313434243521342134343436;
-					# MU;P0=6324;P1=-1789;P2=864;P3=-910;P4=1756;D=0123234143212323232323032321234141032323232323232323;CP=2;
+	"63"	=>	## Warema MU
+						# https://forum.fhem.de/index.php/topic,38831.msg395978/topicseen.html#msg395978 | https://www.mikrocontroller.net/topic/264063
+						# MU;P0=-2988;P1=1762;P2=-1781;P3=-902;P4=871;P5=6762;P6=5012;D=0121342434343434352434313434243521342134343436;
+						# MU;P0=6324;P1=-1789;P2=864;P3=-910;P4=1756;D=0123234143212323232323032321234141032323232323232323;CP=2;
 		{
 			name					=> 'Warema',
 			comment				=> 'developId, is still experimental',
@@ -1283,7 +1290,7 @@
 			#length_max		=> '',			# missing
 			filterfunc		=> 'SIGNALduino_filterMC',
 		},
-	"64"	=>	##  WH2 #############################################################################
+	"64"	=>	## WH2 #############################################################################
 						# MU;P0=-32001;P1=457;P2=-1064;P3=1438;D=0123232323212121232123232321212121212121212323212121232321;CP=1;R=63;
 						# MU;P0=-32001;P1=473;P2=-1058;P3=1454;D=0123232323212121232123232121212121212121212121232321212321;CP=1;R=51;
 						# MU;P0=134;P1=-113;P3=412;P4=-1062;P5=1379;D=01010101013434343434343454345454345454545454345454545454343434545434345454345454545454543454543454345454545434545454345;CP=3;
@@ -1297,7 +1304,7 @@
 			modulematch		=> '^W64*',
 			preamble			=> 'W64#',				# prepend to converted message
 			postamble			=> '',						# Append to converted message
-			#clientmodule => '',
+			#clientmodule	=> '',
 			length_min		=> '48',
 			length_max		=> '54',
 		},
@@ -1318,8 +1325,8 @@
 			length_max				=> '72',
 			postDemodulation	=> \&SIGNALduino_HE_EU,
 		},
-	"66" => ## TX2 Protocol (Remote Temp Transmitter & Remote Thermo Model 7035)
-			# MU;P0=13312;P1=-2785;P2=4985;P3=1124;P4=-6442;P5=3181;P6=-31980;D=0121345434545454545434545454543454545434343454543434545434545454545454343434545434343434545621213454345454545454345454545434545454343434545434345454345454545454543434345454343434345456212134543454545454543454545454345454543434345454343454543454545454545;CP=3;R=73;O;
+	"66"	=>	## TX2 Protocol (Remote Temp Transmitter & Remote Thermo Model 7035)
+						# MU;P0=13312;P1=-2785;P2=4985;P3=1124;P4=-6442;P5=3181;P6=-31980;D=0121345434545454545434545454543454545434343454543434545434545454545454343434545434343434545621213454345454545454345454545434545454343434545434345454345454545454543434345454343434345456212134543454545454543454545454345454543434345454343454543454545454545;CP=3;R=73;O;
 		{
 			name							=> 'WS7035',
 			id								=> '66',
@@ -1373,21 +1380,21 @@
 			length_max		=> '42',
 			paddingbits		=> '8',				 # pad up to 8 bits, default is 4
 		}, 	
-	"69" =>	## Hoermann HSM2, HSM4, HS1-868-BS (868 MHz)
-					# https://github.com/RFD-FHEM/RFFHEM/issues/149
-					# MU;P0=-508;P1=1029;P2=503;P3=-1023;P4=12388;D=01010232323232310104010101010101010102323231010232310231023232323231023101023101010231010101010232323232310104010101010101010102323231010232310231023232323231023101023101010231010101010232323232310104010101010101010102323231010232310231023232323231023101;CP=2;R=37;O;
-					# Remote control HS1-868-BS (one button):
-					# https://github.com/RFD-FHEM/RFFHEM/issues/344
-					# MU;P0=-578;P1=1033;P2=506;P3=-1110;P4=13632;D=0101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010;CP=2;R=77;
-					# MU;P0=-547;P1=1067;P2=553;P3=-1066;P4=13449;D=0101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310;CP=2;R=71;	
-					# https://forum.fhem.de/index.php/topic,71877.msg642879.html (HSM4, Taste 1-4)
-					# MU;P0=-332;P1=92;P2=-1028;P3=12269;P4=-510;P5=1014;P6=517;D=01234545454545454545462626254546262546254626262626254625454625454546254545454546262626262545434545454545454545462626254546262546254626262626254625454625454546254545454546262626262545434545454545454545462626254546262546254626262626254625454625454546254545;CP=6;R=37;O;
-					# MU;P0=509;P1=-10128;P2=1340;P3=-517;P4=1019;P5=-1019;P6=12372;D=01234343434343434343050505434305054305430505050505430543430543434305434343430543050505054343634343434343434343050505434305054305430505050505430543430543434305434343430543050505054343634343434343434343050505434305054305430505050505430543430543434305434343;CP=0;R=52;O;
-					# MU;P0=12376;P1=360;P2=-10284;P3=1016;P4=-507;P6=521;P7=-1012;D=01234343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343;CP=6;R=55;O;
-					# MU;P0=-3656;P1=12248;P2=-519;P3=1008;P4=506;P5=-1033;D=01232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323;CP=4;R=48;O;
+	"69"	=>	## Hoermann HSM2, HSM4, HS1-868-BS (868 MHz)
+						# https://github.com/RFD-FHEM/RFFHEM/issues/149
+						# MU;P0=-508;P1=1029;P2=503;P3=-1023;P4=12388;D=01010232323232310104010101010101010102323231010232310231023232323231023101023101010231010101010232323232310104010101010101010102323231010232310231023232323231023101023101010231010101010232323232310104010101010101010102323231010232310231023232323231023101;CP=2;R=37;O;
+						# Remote control HS1-868-BS (one button):
+						# https://github.com/RFD-FHEM/RFFHEM/issues/344
+						# MU;P0=-578;P1=1033;P2=506;P3=-1110;P4=13632;D=0101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010;CP=2;R=77;
+						# MU;P0=-547;P1=1067;P2=553;P3=-1066;P4=13449;D=0101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310231010232323101010101010101010232323101040101010101010101023232323102323101010231023102310;CP=2;R=71;	
+						# https://forum.fhem.de/index.php/topic,71877.msg642879.html (HSM4, Taste 1-4)
+						# MU;P0=-332;P1=92;P2=-1028;P3=12269;P4=-510;P5=1014;P6=517;D=01234545454545454545462626254546262546254626262626254625454625454546254545454546262626262545434545454545454545462626254546262546254626262626254625454625454546254545454546262626262545434545454545454545462626254546262546254626262626254625454625454546254545;CP=6;R=37;O;
+						# MU;P0=509;P1=-10128;P2=1340;P3=-517;P4=1019;P5=-1019;P6=12372;D=01234343434343434343050505434305054305430505050505430543430543434305434343430543050505054343634343434343434343050505434305054305430505050505430543430543434305434343430543050505054343634343434343434343050505434305054305430505050505430543430543434305434343;CP=0;R=52;O;
+						# MU;P0=12376;P1=360;P2=-10284;P3=1016;P4=-507;P6=521;P7=-1012;D=01234343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343;CP=6;R=55;O;
+						# MU;P0=-3656;P1=12248;P2=-519;P3=1008;P4=506;P5=-1033;D=01232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323;CP=4;R=48;O;
 		{
 			name							=> 'Hoermann',
-			comment						=> 'Remote control HS1-868-BS, HSM4',
+			comment						=> 'remote control HS1-868-BS, HSM4',
 			id								=> '69',
 			zero							=> [2,-1],     # 1020,510
 			one								=> [1,-2],     # 510,1020
@@ -1400,25 +1407,25 @@
 			length_min				=> '44',
 			length_max				=> '44',
 		},
-	"70" => ## FHT80TF (Funk-Tuer-Fenster-Melder FHT 80TF und FHT 80TF-2)
-					# closed MU;P0=-24396;P1=417;P2=-376;P3=610;P4=-582;D=012121212121212121212121234123434121234341212343434121234123434343412343434121234341212121212341212341234341234123434;CP=1;R=35;
-					# open   MU;P0=-21652;P1=429;P2=-367;P4=634;P5=-555;D=012121212121212121212121245124545121245451212454545121245124545454512454545121245451212121212124512451245451245121212;CP=1;R=38;
+	"70"	=>	## FHT80TF (Funk-Tuer-Fenster-Melder FHT 80TF und FHT 80TF-2)
+						# closed MU;P0=-24396;P1=417;P2=-376;P3=610;P4=-582;D=012121212121212121212121234123434121234341212343434121234123434343412343434121234341212121212341212341234341234123434;CP=1;R=35;
+						# open   MU;P0=-21652;P1=429;P2=-367;P4=634;P5=-555;D=012121212121212121212121245124545121245451212454545121245124545454512454545121245451212121212124512451245451245121212;CP=1;R=38;
 		{
 			name							=> 'FHT80TF',
-			comment						=> 'Door/Window switch (868Mhz)',
+			comment						=> 'door/window switch (868Mhz)',
 			id								=> '70',
-			one								=> [1.5,-1.5],	# 600
-			zero							=> [1,-1],	# 400
+			one								=> [1.5,-1.5],		# 600
+			zero							=> [1,-1],				# 400
 			clockabs					=> 400,
-			format						=> 'twostate',  # not used now
+			format						=> 'twostate',		# not used now
 			clientmodule			=> 'CUL_FHTTK',
 			preamble					=> 'T',
 			length_min				=> '50',
 			length_max				=> '58',
 			postDemodulation	=> \&SIGNALduino_postDemo_FHT80TF,
 		},
-	"71" => ## PV-8644 infactory Poolthermometer
-					# MU;P0=1735;P1=-1160;P2=591;P3=-876;D=0123012323010101230101232301230123010101010123012301012323232323232301232323232323232323012301012;CP=2;R=97;
+	"71"	=>	## PV-8644 infactory Poolthermometer
+						# MU;P0=1735;P1=-1160;P2=591;P3=-876;D=0123012323010101230101232301230123010101010123012301012323232323232301232323232323232323012301012;CP=2;R=97;
 		{
 			name					=> 'PV-8644',
 			comment				=> 'infactory Poolthermometer',
@@ -1433,13 +1440,14 @@
 			length_min		=> '48',
 			length_max		=> '48',
 		},
-	"72" => # Siro blinds MU    @Dr. Smag
-			# ! same definition how ID 16 !
-			# https://forum.fhem.de/index.php?topic=77167.0
-			# MU;P0=-760;P1=334;P2=693;P3=-399;P4=-8942;P5=4796;P6=-1540;D=01010102310232310101010102310232323101010102310101010101023102323102323102323102310101010102310232323101010102310101010101023102310231023102456102310232310232310231010101010231023232310101010231010101010102310231023102310245610231023231023231023101010101;CP=1;R=45;O;
-			# MU;P0=-8848;P1=4804;P2=-1512;P3=336;P4=-757;P5=695;P6=-402;D=0123456345656345656345634343434345634565656343434345634343434343456345634563456345;CP=3;R=49;
+	"72"	=>	## Siro blinds MU		@Dr. Smag
+						# ! same definition how ID 16 !
+						# https://forum.fhem.de/index.php?topic=77167.0
+						# MU;P0=-760;P1=334;P2=693;P3=-399;P4=-8942;P5=4796;P6=-1540;D=01010102310232310101010102310232323101010102310101010101023102323102323102323102310101010102310232323101010102310101010101023102310231023102456102310232310232310231010101010231023232310101010231010101010102310231023102310245610231023231023231023101010101;CP=1;R=45;O;
+						# MU;P0=-8848;P1=4804;P2=-1512;P3=336;P4=-757;P5=695;P6=-402;D=0123456345656345656345634343434345634565656343434345634343434343456345634563456345;CP=3;R=49;
 		{
 			name						=> 'Siro shutter',
+			comment					=> 'message decode as MU',
 			id							=> '72',
 			dispatchequals	=>  'true',
 			one							=> [2,-1.2],		# 680, -400
@@ -1454,11 +1462,11 @@
 			length_max			=> '40',
 			msgOutro				=> 'SR;P0=-8500;D=0;',
 		},
-	"72.1"	=>	# Siro blinds MS     @Dr. Smag
+	"72.1"	=>	## Siro blinds MS		@Dr. Smag
 							# MS;P0=4803;P1=-1522;P2=333;P3=-769;P4=699;P5=-393;P6=-9190;D=2601234523454523454523452323232323452345454523232323452323232323234523232345454545;CP=2;SP=6;R=61;
 		{
 			name						=> 'Siro shutter',
-			comment					=> 'developModule. Siro is not in github',
+			comment					=> 'message decode as MS',
 			id							=> '72',
 			developId				=> 'm',
 			dispatchequals	=>  'true',
@@ -1478,14 +1486,14 @@
 						# MU;P0=136;P1=-112;P2=631;P3=-392;P4=402;P5=-592;P6=-8952;D=0123434343434343434343434325434343254325252543432543434343434325434343434343434343254325252543254325434343434343434343434343252525432543464343434343434343434343432543434325432525254343254343434343432543434343434343434325432525254325432543434343434343434;CP=4;R=250;
 		{
 			name							=> 'FHT80',
-			comment						=> 'Roomthermostat (868Mhz only receive)',
+			comment						=> 'roomthermostat (868Mhz only receive)',
 			id								=> '73',
 			developId					=> 'y',
-			one								=> [1.5,-1.5], # 600
-			zero							=> [1,-1], # 400
+			one								=> [1.5,-1.5],	# 600
+			zero							=> [1,-1],			# 400
 			pause							=> [-25],
 			clockabs					=> 400,
-			format						=> 'twostate', # not used now
+			format						=> 'twostate',	# not used now
 			clientmodule			=> 'FHT',
 			preamble					=> '810c04xx0909a001',
 			length_min				=> '59',
@@ -1496,7 +1504,7 @@
 						# MU;P0=-10420;P1=-92;P2=398;P3=-417;P5=596;P6=-592;D=1232323232323232323232323562323235656232323232356232356232623232323232323232323232323235623232323562356565623565623562023232323232323232323232356232323565623232323235623235623232323232323232323232323232323562323232356235656562356562356202323232323232323;CP=2;R=72;
 		{
 			name							=> 'FS20',
-			comment						=> 'Remote Control (868Mhz)',
+			comment						=> 'remote control (868Mhz)',
 			id								=> '74',
 			one								=> [1.5,-1.5],	# 600
 			zero							=> [1,-1],			# 400
@@ -1527,9 +1535,9 @@
 			length_min		=> '32',
 			length_max 		=> '40',
 		},
-	"76"	=>	##  Kabellose LED-Weihnachtskerzen XM21-0
+	"76"	=>	## Kabellose LED-Weihnachtskerzen XM21-0
 		{
-			name					=> 'xm21',
+			name					=> 'LED XM21',
 			comment				=> 'reserviert, LED Lichtrekette on',
 			id						=> '76',
 			developId			=> 'p',
@@ -1543,9 +1551,9 @@
 			length_min		=> 64,
 			length_max		=> 64,
 		},
-	"76.1"	=>	##  Kabellose LED-Weihnachtskerzen XM21-0
+	"76.1"	=>	## Kabellose LED-Weihnachtskerzen XM21-0
 		{
-			name					=> 'xm21',
+			name					=> 'LED XM21',
 			comment				=> 'reserviert, LED Lichtrekette off',
 			id						=> '76.1',
 			developId			=> 'p', 
@@ -1584,8 +1592,9 @@
 			length_max		=> '44',
 			remove_zero		=> 1,						# Removes leading zeros from output
 		},
-	"78" => # MU;P0=313;P1=1212;P2=-309;P4=-2024;P5=-16091;P6=2014;D=01204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040;CP=0;R=236;)
-			# https://forum.fhem.de/index.php/topic,39153.0.html
+	"78"	=>	## geiger blind motors
+						# MU;P0=313;P1=1212;P2=-309;P4=-2024;P5=-16091;P6=2014;D=01204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040;CP=0;R=236;)
+						# https://forum.fhem.de/index.php/topic,39153.0.html
 		{
 			name					=> 'geiger',
 			comment				=> 'geiger blind motors',
@@ -1603,18 +1612,18 @@
 			length_max		=> '18',
 			paddingbits		=> '2'				 # pad 1 bit, default is 4
 		},
-	"79" => ## m-e Funkmodul VTX-BELL
-			# https://github.com/RFD-FHEM/SIGNALDuino/issues/84
-			# MU;P0=656;P1=-656;P2=335;P3=-326;P4=-5024;D=0123012123012303030301 24 230123012123012303030301 24 230123012123012303030301 24 2301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303;CP=2;O;
-			# https://forum.fhem.de/index.php/topic,64251.0.html
-			# MU;P0=540;P1=-421;P2=-703;P3=268;P4=-4948;D=4 323102323101010101010232 34 323102323101010101010232 34 323102323101010101010232 34 3231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010;CP=3;O;
-			# https://github.com/RFD-FHEM/RFFHEM/issues/252
-			# MU;P0=-24096;P1=314;P2=-303;P3=615;P4=-603;P5=220;P6=-4672;D=0123456123412341414141412323234 16 123412341414141412323234 16 12341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414;CP=1;R=26;O;
-			# MU;P0=-10692;P1=602;P2=-608;P3=311;P4=-305;P5=-4666;D=01234123232323234141412 35 341234123232323234141412 35 341234123232323234141412 35 34123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414;CP=3;R=47;O;
-			# MU;P0=-7152;P1=872;P2=-593;P3=323;P4=-296;P5=622;P6=-4650;D=01234523232323234545452 36 345234523232323234545452 36 345234523232323234545452 36 34523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454;CP=3;R=26;O;
+	"79"	=>	## Heidemann | Heidemann HX | VTX-BELL
+						# https://github.com/RFD-FHEM/SIGNALDuino/issues/84
+						# MU;P0=656;P1=-656;P2=335;P3=-326;P4=-5024;D=0123012123012303030301 24 230123012123012303030301 24 230123012123012303030301 24 2301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303;CP=2;O;
+						# https://forum.fhem.de/index.php/topic,64251.0.html
+						# MU;P0=540;P1=-421;P2=-703;P3=268;P4=-4948;D=4 323102323101010101010232 34 323102323101010101010232 34 323102323101010101010232 34 3231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010;CP=3;O;
+						# https://github.com/RFD-FHEM/RFFHEM/issues/252
+						# MU;P0=-24096;P1=314;P2=-303;P3=615;P4=-603;P5=220;P6=-4672;D=0123456123412341414141412323234 16 123412341414141412323234 16 12341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414;CP=1;R=26;O;
+						# MU;P0=-10692;P1=602;P2=-608;P3=311;P4=-305;P5=-4666;D=01234123232323234141412 35 341234123232323234141412 35 341234123232323234141412 35 34123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414;CP=3;R=47;O;
+						# MU;P0=-7152;P1=872;P2=-593;P3=323;P4=-296;P5=622;P6=-4650;D=01234523232323234545452 36 345234523232323234545452 36 345234523232323234545452 36 34523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454;CP=3;R=26;O;
 		{
-			name					=> 'm-e VTX-BELL',
-			comment				=> 'wireless chime VTX-BELL',
+			name					=> 'doorbell',
+			comment				=> 'Heidemann | Heidemann HX | VTX-BELL',
 			id						=> '79',
 			zero					=> [-2,1],
 			one						=> [-1,2],
@@ -1627,8 +1636,8 @@
 			length_min		=> '12',
 			length_max		=> '12',
 		},
-	"80" => ## EM (Energy-Monitor) Funkprotokoll (868Mhz),  @HomeAutoUser | Derwelcherichbin
-			# MU;P1=-417;P2=385;P3=-815;P4=-12058;D=42121212121212121212121212121212121232321212121212121232321212121212121232323212323212321232121212321212123232121212321212121232323212121212121232121212121212121232323212121212123232321232121212121232123232323212321;CP=2;R=87;
+	"80"	=>	## EM (Energy-Monitor) Funkprotokoll (868Mhz),  @HomeAutoUser | Derwelcherichbin
+						# MU;P1=-417;P2=385;P3=-815;P4=-12058;D=42121212121212121212121212121212121232321212121212121232321212121212121232323212323212321232121212321212123232121212321212121232323212121212121232121212121212121232323212121212123232321232121212121232123232323212321;CP=2;R=87;
 		{
 			name							=> 'EM (Energy-Monitor)',
 			comment						=> 'EM (Energy-Monitor) (868Mhz)',
@@ -1652,7 +1661,7 @@
 						# short 500 microSec / long 1000 microSec / bittime 1500 mikroSek / pilot 12 * bittime, from that 1/3 bitlength high
 		{
 			name					=> 'SA-434-1',
-			comment				=> 'Remote control SA-434-1 mini 923301 based on HT12E (developModule SD_UT is only in github available)',
+			comment				=> 'remote control SA-434-1 mini 923301 based on HT12E',
 			id						=> '81',
 			one						=> [-2,1],			# i.O.
 			zero					=> [-1,2],			# i.O.
@@ -1693,7 +1702,7 @@
 						# Taste 3 MU;P0=564;P1=-392;P2=-713;P3=245;P4=-11247;D=0101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023;CP=3;R=40;O;
 		{
 			name					=> 'RH787T',
-			comment				=> 'Remote control for example Westinghouse Delancey 7800140 (developModule SD_UT is only in github available)',
+			comment				=> 'remote control for example Westinghouse Delancey 7800140',
 			id						=> '83',
 			one						=> [-2,1],
 			zero					=> [-1,2],
@@ -1736,21 +1745,21 @@
 						# MU;P0=-504;P1=481;P2=-254;P3=227;P4=723;P5=-739;P6=-1848;D=01230121212303030121230303030303030453030303012123030301230303012301212303030303030304530303030121230303012303030123012121230303012123030303030303030123030123030123030123012123030303030123012301230123012303012121212364545454530303030121230303012303030123;CP=3;R=45;O;
 						# MU;P0=7944;P1=-724;P2=742;P3=241;P4=-495;P5=483;P6=-248;D=01212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634345656345634343456563421212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634;CP=3;R=47;O;�
 		{
-			name         => 'TFA 30.3222.02',
-			comment      => 'Combisensor for Weatherstation TFA 35.1140.01',
-			id           => '85',
-			one          => [2,-1],
-			zero         => [1,-2],
-			start        => [3,-3,3,-3,3,-3],
-			clockabs     => 250, 
-			format       => 'twostate',
-			preamble     => 'W85#',					# prepend to converted message
-			postamble    => '',							# append to converted message
-			clientmodule => 'SD_WS',
-			length_min   => '64',
-			length_max   => '68',
+			name					=> 'TFA 30.3222.02',
+			comment				=> 'Combisensor for Weatherstation TFA 35.1140.01',
+			id						=> '85',
+			one						=> [2,-1],
+			zero					=> [1,-2],
+			start					=> [3,-3,3,-3,3,-3],
+			clockabs			=> 250, 
+			format				=> 'twostate',
+			preamble			=> 'W85#',					# prepend to converted message
+			postamble			=> '',							# append to converted message
+			clientmodule	=> 'SD_WS',
+			length_min		=> '64',
+			length_max		=> '68',
 		},
-	"86"	=>	## for remote controls:  Novy 840029, CAME TOP 432EV, Neff Transmitter SF01 01319004
+	"86"	=>	### for remote controls:  Novy 840029, CAME TOP 432EV, OSCH & Neff Transmitter SF01 01319004
 						### CAME TOP 432EV 433,92 MHz für z.B. Drehtor Antrieb:
 						# https://forum.fhem.de/index.php/topic,63370.msg849400.html#msg849400
 						# https://github.com/RFD-FHEM/RFFHEM/issues/151
@@ -1765,16 +1774,22 @@
 						# minus button         # MU;P0=-8032;P1=364;P2=-398;P3=700;P4=-760;P5=-15980;D=0123412341234123412341412351234123412341234123414123512341234123412341234141235123412341234123412341412351234123412341234123414123;CP=1;R=40;
 						# power button         # MU;P0=-756;P1=718;P2=354;P3=-395;P4=-16056;D=01020202310231310202 42 310231023102310231020202310231310202 42 31023102310231023102020231023131020242310231023102310231020202310231310202;CP=2;R=41;
 						# novy button          # MU;P0=706;P1=-763;P2=370;P3=-405;P4=-15980;D=0123012301230304230123012301230123012303042;CP=2;R=42;
-						### Neff Transmitter SF01 01319004 433,92 MHz for kitchen hood:
+						### Neff Transmitter SF01 01319004 (SF01_01319004) 433,92 MHz
 						# https://github.com/RFD-FHEM/RFFHEM/issues/376
+						# MU;P0=-707;P1=332;P2=-376;P3=670;P5=-15243;D=01012301232323230123012301232301010123510123012323232301230123012323010101235101230123232323012301230123230101012351012301232323230123012301232301010123510123012323232301230123012323010101235101230123232323012301230123230101012351012301232323230123012301;CP=1;R=3;O;
+						# MU;P0=-32001;P1=348;P2=-704;P3=-374;P4=664;P5=-15255;D=01213421343434342134213421343421213434512134213434343421342134213434212134345121342134343434213421342134342121343451213421343434342134213421343421213434512134213434343421342134213434212134345121342134343434213421342134342121343451213421343434342134213421;CP=1;R=15;O;
+						# MU;P0=-32001;P1=326;P2=-721;P3=-385;P4=656;P5=-15267;D=01213421343434342134213421343421342134512134213434343421342134213434213421345121342134343434213421342134342134213451213421343434342134213421343421342134512134213434343421342134213434213421345121342134343434213421342134342134213451213421343434342134213421;CP=1;R=10;O;
+						# MU;P0=-372;P1=330;P2=684;P3=-699;P4=-14178;D=010231020202023102310231020231310231413102310202020231023102310202313102314;CP=1;R=253;
+						# MU;P0=-710;P1=329;P2=-388;P3=661;P4=-14766;D=01232301410123012323232301230123012323012323014;CP=1;R=1;
+						### BOSCH Transmitter SF01 01319004 (SF01_01319004_Typ2) 433,92 MHz
 						# MU;P0=706;P1=-160;P2=140;P3=-335;P4=-664;P5=385;P6=-15226;P7=248;D=01210103045303045453030304545453030454530653030453030454530303045454530304747306530304530304545303030454545303045453065303045303045453030304545453030454530653030453030454530303045454530304545306530304530304545303030454545303045453065303045303045453030304;CP=5;O;
 						# MU;P0=-15222;P1=379;P2=-329;P3=712;P6=-661;D=30123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616;CP=1;O;
 						# MU;P0=705;P1=-140;P2=-336;P3=-667;P4=377;P5=-15230;P6=248;D=01020342020343420202034343420202020345420203420203434202020343434202020203654202034202034342020203434342020202034542020342020343420202034343420202020345420203420203434202020343434202020203454202034202034342020203434342020202034542020342020343420202034343;CP=4;O;
 						# MU;P0=704;P1=-338;P2=-670;P3=378;P4=-15227;P5=244;D=01023231010102323231010102310431010231010232310101023232310101025104310102310102323101010232323101010231043101023101023231010102323231010102310431010231010232310101023232310101023104310102310102323101010232323101010231043101023101023231010102323231010102;CP=3;O;
 						# MU;P0=-334;P1=709;P2=-152;P3=-663;P4=379;P5=-15226;P6=250;D=01210134010134340101013434340101340134540101340101343401010134343401013601365401013401013434010101343434010134013454010134010134340101013434340101340134540101340101343401010134343401013401345401013401013434010101343434010134013454010134010134340101013434;CP=4;O;
 		{
-			name					=> 'CAME|Novy|Neff',
-			comment				=> 'CAME TOP 432EV, Novy 840029, Neff SF01 01319004',
+			name					=> 'BOSCH|CAME|Novy|Neff',
+			comment				=> 'remote control CAME TOP 432EV, Novy 840029, BOSCH or Neff SF01 01319004',
 			id						=> '86',
 			one						=> [-2,1],
 			zero					=> [-1,2],
@@ -1793,7 +1808,7 @@
 						# MS;P0=-15967;P1=1530;P2=-450;P3=368;P4=-3977;P5=-835;P6=754;D=34353562623535623562623562356262626235353562623562623562626235353562623562626262626262626262626262623535626235623535353535626262356262626262626260123232323232323232323232;CP=3;SP=4;R=229;O;
 		{
 			name					=> 'JAROLIFT',
-			comment				=> 'JAROLIFT TDRC_16W / TDRCT_04W',
+			comment				=> 'remote control JAROLIFT TDRC_16W / TDRCT_04W',
 			id						=> '87',
 			one						=> [1,-2],
 			zero					=> [2,-1],
@@ -1812,8 +1827,8 @@
 						# MS;P1=361;P2=-435;P4=-4018;P5=-829;P6=759;P7=-16210;D=141562156215156262626215151562626215626215621562151515621562151515156262156262626215151562156215621515151515151562151515156262156215171212121212121212121212;CP=1;SP=4;R=66;O;m0;
 						# MS;P0=-16052;P1=363;P2=-437;P3=-4001;P4=-829;P5=755;D=131452521452145252521452145252521414141452521452145214141414525252145252145252525214141452145214521414141414141452141414145252145252101212121212121212121212;CP=1;SP=3;R=51;O;m1;
 		{
-			name					=> 'Roto',
-			comment				=> 'Roto TX-nM-HCS',
+			name					=> 'Roto shutter',
+			comment				=> 'remote control Aurel TX-nM-HCS',
 			id						=> '88',
 			one						=> [1,-2],
 			zero					=> [2,-1],
@@ -1821,10 +1836,10 @@
 			clockabs			=> 400,						# ca 400us
 			developId			=> 'y',
 			format				=> 'twostate',
-			preamble			=> 'u88#',				# prepend to converted message	
+			preamble			=> 'u88#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
-			length_min		=> '68',
-			length_max		=> '68',
+			length_min		=> '65',
+			length_max		=> '78',
 		},
 );

--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -37,7 +37,7 @@
 # clientmodule => ' '      # FHEM module for processing
 # filterfunc  => ' '       # SIGNALduino_filterSign | SIGNALduino_compPattern --> SIGNALduino internal filter function, it remove the sign from the pattern, and compress message and pattern
 #                          # SIGNALduino_filterMC --> SIGNALduino internal filter function, it will decode MU data via Manchester encoding
-# dispatchBin => 1,		   # If set to 1, data will be dispatched in binary representation to other logcial modules. 
+# dispatchBin => 1,        # If set to 1, data will be dispatched in binary representation to other logcial modules. 
 #                            If not set (default) or set to 0, data will be dispatched in hex mode to other logical modules.
 # postDemodulation => \&   # only MU - SIGNALduino internal sub for processing before dispatching to a logical module
 # method      => \&        # call to process this message
@@ -65,34 +65,34 @@
 			id							=> '0',
 			one							=> [1,-8],
 			zero						=> [1,-4],
-			sync						=> [1,-18],		
+			sync						=> [1,-18],
 			clockabs				=> '500',
-			format					=> 'twostate',  # not used now
-			preamble				=> 's',			# prepend to converted message	 	
-			postamble				=> '00',		# Append to converted message	 	
-			clientmodule    => 'CUL_TCM97001',
-			#modulematch     => '^s[A-Fa-f0-9]+',
-			length_min      => '24',
-			length_max      => '42',
-			paddingbits     => '8',				 # pad up to 8 bits, default is 4
+			format					=> 'twostate',	# not used now
+			preamble				=> 's',					# prepend to converted message
+			postamble				=> '00',				# Append to converted message
+			clientmodule		=> 'CUL_TCM97001',
+			#modulematch		=> '^s[A-Fa-f0-9]+',
+			length_min			=> '24',
+			length_max			=> '42',
+			paddingbits			=> '8',					# pad up to 8 bits, default is 4
 		},
-	"1"	=> 	# ConradRSL
+	"1"	=>	# ConradRSL
 		{
 			name					=> 'ConradRSL',
-			id          	=> '1',
+			id						=> '1',
 			one						=> [2,-1],
 			zero					=> [1,-2],
-			sync					=> [1,-11],		
-			clockabs   		=> '560',
-			format     		=> 'twostate',  		# not used now
-			preamble			=> 'P1#',					# prepend to converted message	 	
-			postamble			=> '',					# Append to converted message	 	
+			sync					=> [1,-11],
+			clockabs			=> '560',
+			format				=> 'twostate',		# not used now
+			preamble			=> 'P1#',					# prepend to converted message
+			postamble			=> '',						# Append to converted message
 			clientmodule	=> 'SD_RSL',
 			modulematch		=> '^P1#[A-Fa-f0-9]{8}',
-			length_min 		=> '20',   # 23
-			length_max 		=> '40',   # 24
+			length_min		=> '20',					# 23
+			length_max		=> '40',					# 24
 		},
-	"2"	=> # Self build arduino sensor
+	"2"	=>	# Self build arduino sensor
 		{
 			name						=> 'AS, Self build arduino sensor',
 			comment					=> 'developModule. SD_AS module is only in github available',
@@ -102,37 +102,37 @@
 			zero						=> [1,-1],
 			sync						=> [1,-20],
 			clockabs				=> '500',
-			format					=> 'twostate',	
-			preamble				=> 'P2#',		# prepend to converted message		
-			clientmodule    => 'SD_AS',
-			modulematch     => '^P2#.{7,8}',
-			length_min      => '32',
-			length_max      => '34',		# Don't know maximal lenth of a valid message
-			paddingbits     => '8',		    # pad up to 8 bits, default is 4
+			format					=> 'twostate',
+			preamble				=> 'P2#',				# prepend to converted message
+			clientmodule		=> 'SD_AS',
+			modulematch			=> '^P2#.{7,8}',
+			length_min			=> '32',
+			length_max			=> '34',				# Don't know maximal lenth of a valid message
+			paddingbits			=> '8',					# pad up to 8 bits, default is 4
 		},
 	"3"	=>	# remote like WOFI Lamp
 					# need more Device Infos / User Message
 		{
-			name						=> 'itv1',	
+			name						=> 'itv1',
 			comment         => 'example: remote for WOFI',
 			id							=> '3',
 			one							=> [3,-1],
 			zero						=> [1,-3],
-			#float				=> [-1,3],		# not full supported now later use
+			#float					=> [-1,3],			# not full supported now later use
 			sync						=> [1,-31],
-			clockabs				=> -1,	# -1=auto	
+			clockabs				=> -1,					# -1=auto
 			format					=> 'twostate',	# not used now
-			preamble				=> 'i',			
-			clientmodule    => 'IT',
-			modulematch     => '^i......',
-			length_min      => '24',
-			length_max      => '24',		# Don't know maximal lenth of a valid message
+			preamble				=> 'i',
+			clientmodule		=> 'IT',
+			modulematch			=> '^i......',
+			length_min			=> '24',
+			length_max			=> '24',				# Don't know maximal lenth of a valid message
 		},
 	"3.1"	=>	# MS;P0=-11440;P1=-1121;P2=-416;P5=309;P6=1017;D=150516251515162516251625162516251515151516251625151;CP=5;SP=0;R=66;
 						# MS;P1=309;P2=-1130;P3=1011;P4=-429;P5=-11466;D=15123412121234123412141214121412141212123412341234;CP=1;SP=5;R=38;  Gruppentaste, siehe Kommentar in sub SIGNALduino_bit2itv1
 						# need more Device Infos / User Message
 		{
-			name						=> 'itv1_sync40',	
+			name						=> 'itv1_sync40',
 			comment					=> 'IT remote Control PAR 1000, ITS-150, AB440R',
 			id							=> '3',
 			one             => [3.5,-1],
@@ -148,24 +148,24 @@
 			length_max      => '24',		# Don't know maximal lenth of a valid message
 			postDemodulation => \&SIGNALduino_bit2itv1,
 		},
-	"4"	=> # need more Device Infos / User Message
+	"4"	=>	# need more Device Infos / User Message
 		{
-			name						=> 'arctech2',	
+			name						=> 'arctech2',
 			id							=> '4',
-			#one					=> [1,-5,1,-1],  
-			#zero					=> [1,-1,1,-5],  
-			one							=> [1,-5],  
-			zero						=> [1,-1],  
-			#float				=> [-1,3],		# not full supported now, for later use
+			#one						=> [1,-5,1,-1],
+			#zero						=> [1,-1,1,-5],
+			one							=> [1,-5],
+			zero						=> [1,-1],
+			#float					=> [-1,3],			# not full supported now, for later use
 			sync						=> [1,-14],
-			clockabs    	 	=> -1,			# -1 = auto
+			clockabs				=> -1,					# -1 = auto
 			format					=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble				=> 'i',			# Append to converted message	
-			postamble				=> '00',		# Append to converted message	 	
-			clientmodule    => 'IT',
-			modulematch     => '^i......',
-			length_min      => '39',
-			length_max      => '44',		# Don't know maximal lenth of a valid message
+			preamble				=> 'i',					# Append to converted message
+			postamble				=> '00',				# Append to converted message
+			clientmodule		=> 'IT',
+			modulematch			=> '^i......',
+			length_min			=> '39',
+			length_max			=> '44',		# Don't know maximal lenth of a valid message
 		},
 	"5"	=>	# Unitec, Modellnummer 6899/45108
 					# https://github.com/RFD-FHEM/RFFHEM/pull/389#discussion_r237232347 | https://github.com/RFD-FHEM/RFFHEM/pull/389#discussion_r237245943
@@ -177,147 +177,147 @@
 					# A AUS:
 					# MU;P0=-1692;P1=132;P2=194;P4=355;P5=474;P7=-31892;D=010202040505050505050404040404040404040470;CP=4;R=27; 
 		{
-			name						=> 'unitec',	
+			name						=> 'unitec',
 			comment					=> 'model 6899/45108',
 			id							=> '5',
-			one							=> [3,-1], # ?
-			zero						=> [1,-3], # ?
-			clockabs				=> 500,    # ?
-			developId       => 'y',
+			one							=> [3,-1],		# ?
+			zero						=> [1,-3],		# ?
+			clockabs				=> 500,				# ?
+			developId				=> 'y',
 			format					=> 'twostate',
 			preamble				=> 'u5',
 			#clientmodule    => '',
 			#modulematch     => '',
-			length_min      => '24',   # ?
-			length_max      => '24',   # ?
-		},    
+			length_min      => '24',			# ?
+			length_max      => '24',			# ?
+		},
 	"6"	=>	## Eurochron Protocol
 		{
-			name					=> 'weatherID6',	
-			id          	=> '6',
+			name					=> 'weatherID6',
+			id						=> '6',
 			one						=> [1,-10],
 			zero					=> [1,-5],
 			sync					=> [1,-36],			# This special device has no sync
-			clockabs     	=> 220,					# -1 = auto
+			clockabs			=> 220,					# -1 = auto
 			format				=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble			=> 'u6#',				# Append to converted message	
-			#clientmodule    => '',
-			#modulematch     => '^u......',
+			preamble			=> 'u6#',				# Append to converted message
+			#clientmodule	=> '',
+			#modulematch	=> '^u......',
 			length_min		=> '24',
-			#length_max		 => '36',		# missing
+			#length_max		=> '36',				# missing
 		},
 	"7"	=> ## weather sensors like EAS800z
 					# MS;P1=-3882;P2=504;P3=-957;P4=-1949;D=21232424232323242423232323232323232424232323242423242424242323232324232424;CP=2;SP=1;R=249;m=2;
 		{
-			name						=> 'weatherID7',	
+			name						=> 'weatherID7',
 			comment					=> 'EAS800z, FreeTec NC-7344, HAMA TS34A',
-			id          		=> '7',
+			id							=> '7',
 			one							=> [1,-4],
 			zero						=> [1,-2],
-			sync						=> [1,-8],		 
-			clockabs     		=> 484,			
-			format					=> 'twostate',	
-			preamble				=> 'P7#',		# prepend to converted message	
-			clientmodule    => 'SD_WS07',
-			modulematch     => '^P7#.{6}F.{2}',
-			length_min      => '35',
-			length_max      => '40',
+			sync						=> [1,-8],
+			clockabs				=> 484,
+			format					=> 'twostate',
+			preamble				=> 'P7#',				# prepend to converted message
+			clientmodule		=> 'SD_WS07',
+			modulematch			=> '^P7#.{6}F.{2}',
+			length_min			=> '35',
+			length_max			=> '40',
 		}, 
 	"8"	=>	## TX3 (ITTX) Protocol
 					# MU;P0=-1046;P1=1339;P2=524;P3=-28696;D=010201010101010202010101010202010202020102010101020101010202020102010101010202310101010201020101010101020201010101020201020202010201010102010101020202010201010101020;CP=2;R=4;
 		{
-			name						=> 'TX3 Protocol',	
-			id          		=> '8',
+			name						=> 'TX3 Protocol',
+			id							=> '8',
 			one							=> [1,-2],
 			zero						=> [2,-2],
-			#sync					=> [1,-8],		# 
+			#sync						=> [1,-8],			# 
 			clockabs				=> 470,
-			format					=> 'pwm',	    # 
-			preamble				=> 'TX',		# prepend to converted message	
-			clientmodule    => 'CUL_TX',
-			modulematch     => '^TX......',
-			length_min      => '43',
-			length_max      => '44',
-			remove_zero     => 1,           # Removes leading zeros from output
-		}, 	
+			format					=> 'pwm',				# 
+			preamble				=> 'TX',				# prepend to converted message
+			clientmodule		=> 'CUL_TX',
+			modulematch			=> '^TX......',
+			length_min			=> '43',
+			length_max			=> '44',
+			remove_zero			=> 1,						# Removes leading zeros from output
+		},
 	"9"	=>	## Funk Wetterstation CTW600
 		{
-			name						=> 'CTW 600',	
-			comment         => 'FunkWS WH1080/WH3080/CTW600',
+			name						=> 'CTW 600',
+			comment					=> 'FunkWS WH1080/WH3080/CTW600',
 			id							=> '9',
 			zero						=> [3,-2],
 			one							=> [1,-2],
-			#float			=> [-1,3],		# not full supported now, for later use
-			#sync				=> [1,-8],		# 
-			clockabs				=> 480,			# -1 = auto undef=noclock
-			format					=> 'pwm',	    # tristate can't be migrated from bin into hex!
-			preamble				=> 'P9#',		# prepend to converted message	
-			clientmodule    => 'SD_WS09',
-			#modulematch     => '^u9#.....',
-			length_min      => '60',
-			length_max      => '120',
-		}, 	
+			#float					=> [-1,3],			# not full supported now, for later use
+			#sync						=> [1,-8],			# 
+			clockabs				=> 480,					# -1 = auto undef=noclock
+			format					=> 'pwm',				# tristate can't be migrated from bin into hex!
+			preamble				=> 'P9#',				# prepend to converted message	
+			clientmodule		=> 'SD_WS09',
+			#modulematch		=> '^u9#.....',
+			length_min			=> '60',
+			length_max			=> '120',
+		},
 	"10"	=>	## Oregon Scientific 2
 		{
-			name						=> 'OSV2o3',	
+			name						=> 'OSV2o3',
 			id							=> '10',
-			clockrange     	=> [300,520],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			clientmodule    => 'OREGON',
-			modulematch     => '^(3[8-9A-F]|[4-6][0-9A-F]|7[0-8]).*',
-			length_min      => '64',
-			length_max      => '220',
-			method          => \&SIGNALduino_OSV2, # Call to process this message
-			polarity        => 'invert',			
-		}, 	
+			clockrange			=> [300,520],						# min , max
+			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
+			clientmodule		=> 'OREGON',
+			modulematch			=> '^(3[8-9A-F]|[4-6][0-9A-F]|7[0-8]).*',
+			length_min			=> '64',
+			length_max			=> '220',
+			method					=> \&SIGNALduino_OSV2,	# Call to process this message
+			polarity				=> 'invert',
+		},
 	"11"	=>	## Arduino Sensor
 		{
 			name						=> 'AS',	
 			id							=> '11',
-			clockrange     	=> [380,425],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			preamble				=> 'P2#',		# prepend to converted message	
-			clientmodule    => 'SD_AS',
-			modulematch     => '^P2#.{7,8}',
-			length_min      => '52',
-			length_max      => '56',
-			method          => \&SIGNALduino_AS # Call to process this message
-		}, 
+			clockrange			=> [380,425],						# min , max
+			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
+			preamble				=> 'P2#',								# prepend to converted message
+			clientmodule		=> 'SD_AS',
+			modulematch			=> '^P2#.{7,8}',
+			length_min			=> '52',
+			length_max			=> '56',
+			method					=> \&SIGNALduino_AS # Call to process this message
+		},
 	"12"	=>	## Hideki
 						# MC;LL=-1040;LH=904;SL=-542;SH=426;D=A8C233B53A3E0A0783;C=485;L=72;R=213;
 		{
-			name						=> 'Hideki protocol',	
-			comment         => 'Hideki messages are sometimes received as inverted (check in sub)',
+			name						=> 'Hideki protocol',
+			comment					=> 'Hideki messages are sometimes received as inverted (check in sub)',
 			id							=> '12',
-			clockrange     	=> [420,510],                   # min, max better for Bresser Sensors, OK for hideki/Hideki/TFA too     
-			format					=> 'manchester',	
-			preamble				=> 'P12#',						# prepend to converted message	
-			clientmodule    => 'hideki',
-			modulematch     => '^P12#75.+',
-			length_min      => '71',
-			length_max      => '128',
-			method          => \&SIGNALduino_Hideki,	# Call to process this message
-			#polarity        => 'invert',			
-		}, 	
+			clockrange			=> [420,510],							# min, max better for Bresser Sensors, OK for hideki/Hideki/TFA too
+			format					=> 'manchester',
+			preamble				=> 'P12#',								# prepend to converted message
+			clientmodule		=> 'hideki',
+			modulematch			=> '^P12#75.+',
+			length_min			=> '71',
+			length_max			=> '128',
+			method					=> \&SIGNALduino_Hideki,	# Call to process this message
+			#polarity				=> 'invert',
+		},
 	"13"	=>	## FLAMINGO  FA 21
 						# https://github.com/RFD-FHEM/RFFHEM/issues/21
 						# https://github.com/RFD-FHEM/RFFHEM/issues/233
 						# MS;P0=-1413;P1=757;P2=-2779;P3=-16079;P4=8093;P5=-954;D=1345121210101212101210101012121012121210121210101010;CP=1;SP=3;R=33;O;
 		{
-			name						=> 'FLAMINGO FA21',	
+			name						=> 'FLAMINGO FA21',
 			id							=> '13',
 			one							=> [1,-2],
 			zero						=> [1,-4],
-			sync						=> [1,-20,10,-1],		
+			sync						=> [1,-20,10,-1],
 			clockabs				=> 800,
-			format					=> 'twostate',	  		
+			format					=> 'twostate',
 			preamble				=> 'P13#',				# prepend to converted message	
-			clientmodule    => 'FLAMINGO',
-			#modulematch     => 'P13#.*',
-			length_min      => '24',
-			length_max      => '26',
-		}, 		
-	"13.1"  =>	## FLAMINGO FA20RF
+			clientmodule		=> 'FLAMINGO',
+			#modulematch		=> 'P13#.*',
+			length_min			=> '24',
+			length_max			=> '26',
+		},
+	"13.1"	=>	## FLAMINGO FA20RF
 							# MU;P0=-1384;P1=815;P2=-2725;P3=-20001;P4=8159;P5=-891;D=01010121212121010101210101345101210101210101212101010101012121212101010121010134510121010121010121210101010101212121210101012101013451012101012101012121010101010121212121010101210101345101210101210101212101010101012121212101010121010134510121010121010121;CP=1;O;
 							# MU;P0=-17201;P1=112;P2=-1419;P3=-28056;P4=8092;P5=-942;P6=777;P7=-2755;D=12134567676762626762626762626767676762626762626267626260456767676262676262676262676767676262676262626762626045676767626267626267626267676767626267626262676262604567676762626762626762626767676762626762626267626260456767676262676262676262676767676262676262;CP=6;O;
 							## FLAMINGO FA22RF (only MU Message)
@@ -326,21 +326,21 @@
 							# Sync 8100 microSec, 900 microSec | Bit1 2700 microSec low - 800 microSec high | Bit0 1400 microSec low - 800 microSec high | Pause Repeat 20000 microSec | 1 Sync + 24Bit, Totaltime 65550 microSec without Sync
 		{
 			name						=> 'FLAMINGO FA22RF / FA21RF / LM-101LD',
-			comment         => 'FLAMINGO oder Unitec Rauchmelder',
+			comment					=> 'FLAMINGO oder Unitec Rauchmelder',
 			id							=> '13.1',
 			one							=> [1,-1.8],
 			zero						=> [1,-3.5],
 			start						=> [10,-1],
-			pause           => [-25],
+			pause						=> [-25],
 			clockabs				=> 800,
-			format					=> 'twostate',	  		
-			preamble				=> 'P13.1#',				# prepend to converted message	
-			clientmodule    => 'FLAMINGO',
-			#modulematch     => '^P13\.?1?#[A-Fa-f0-9]+',
-			length_min      => '24',
-			length_max      => '24',
-		}, 		
-	"13.2" => ##	MS;P1=-2708;P2=796;P3=-1387;P4=-8477;P5=8136;P6=-904;D=2456212321212323232321212121212121212123212321212121;CP=2;SP=4;
+			format					=> 'twostate',
+			preamble				=> 'P13.1#',				# prepend to converted message
+			clientmodule		=> 'FLAMINGO',
+			#modulematch		=> '^P13\.?1?#[A-Fa-f0-9]+',
+			length_min			=> '24',
+			length_max			=> '24',
+		},
+	"13.2" => ## MS;P1=-2708;P2=796;P3=-1387;P4=-8477;P5=8136;P6=-904;D=2456212321212323232321212121212121212123212321212121;CP=2;SP=4;
 		{
 			name						=> 'LM-101LD Rauchm',
 			comment					=> 'Unitec Rauchmelder',
@@ -358,76 +358,76 @@
 		},
 	"14"	=>	## Heidemann HX BELL
 		{
-			name						=> 'Heidemann HX',	
-			comment         => 'Heidemann HX doorbell',										
+			name						=> 'Heidemann HX',
+			comment					=> 'Heidemann HX doorbell',
 			id							=> '14',
 			one							=> [1,-2],
 			zero						=> [1,-1],
 			#float					=> [-1,3],				# not full supported now, for later use
 			sync						=> [1,-14],
 			clockabs				=> 350,
-			format					=> 'twostate',	  		
-			preamble				=> 'P14#',				# prepend to converted message	
-			clientmodule    => 'SD_BELL',
-			modulematch     => '^P14#.*',
-			length_min      => '12',
-			length_max      => '20',
-		}, 			
+			format					=> 'twostate',
+			preamble				=> 'P14#',				# prepend to converted message
+			clientmodule		=> 'SD_BELL',
+			modulematch			=> '^P14#.*',
+			length_min			=> '12',
+			length_max			=> '20',
+		},
 	"15"	=>	## TCM 234759
 		{
-			name						=> 'TCM 234759 Bell',	
-			comment         => 'wireless doorbell TCM 234759 Tchibo',			
+			name						=> 'TCM 234759 Bell',
+			comment					=> 'wireless doorbell TCM 234759 Tchibo',
 			id							=> '15',
 			one							=> [1,-1],
 			zero						=> [1,-2],
 			sync						=> [1,-45],
 			clockabs				=> 700,
-			format					=> 'twostate',	  		
-			preamble				=> 'P15#',				# prepend to converted message	
-			clientmodule    => 'SD_BELL',
-			modulematch     => '^P15#.*',
-			length_min      => '10',
-			length_max      => '20',
-		}, 	
+			format					=> 'twostate',
+			preamble				=> 'P15#',				# prepend to converted message
+			clientmodule		=> 'SD_BELL',
+			modulematch			=> '^P15#.*',
+			length_min			=> '10',
+			length_max			=> '20',
+		},
 	"16" => # Rohrmotor24 und andere Funk Rolladen / Markisen Motoren
 					# ! same definition how ID 72 !
 					# https://forum.fhem.de/index.php/topic,49523.0.html
 					# MU;P0=-1608;P1=-785;P2=288;P3=650;P4=-419;P5=4676;D=1212121213434212134213434212121343434212121213421213434212134345021213434213434342121212121343421213421343421212134343421212121342121343421213432;CP=2;
 					# MU;P0=-1562;P1=-411;P2=297;P3=-773;P4=668;P5=4754;D=1232341234141234141234141414123414123232341232341412323414150234123234123232323232323234123414123414123414141412341412323234123234141232341415023412323412323232323232323412341412341412341414141234141232323412323414123234142;CP=2;
 		{
-			name						=> 'Dooya shutter',	
+			name						=> 'Dooya shutter',
 			id							=> '16',
 			one							=> [2,-1],
 			zero						=> [1,-3],
-			start           => [17,-5],
+			start						=> [17,-5],
 			clockabs				=> 280,
-			format					=> 'twostate',	  		
-			preamble				=> 'P16#',				# prepend to converted message	
-			clientmodule    => 'Dooya',
-			#modulematch     => '',
-			length_min      => '39',
-			length_max      => '40',
-		}, 	
-    "17"	=> # need more Device Infos / User Message
+			format					=> 'twostate',
+			preamble				=> 'P16#',				# prepend to converted message
+			clientmodule		=> 'Dooya',
+			#modulematch		=> '',
+			length_min			=> '39',
+			length_max			=> '40',
+		},
+	"17"	=> # need more Device Infos / User Message
 		{
-			name						=> 'arctech / intertechno',
-			id							=> '17',
-			one							=> [1,-5,1,-1],  
-			zero						=> [1,-1,1,-5],  
-			#one			=> [1,-5],  
-			#zero			=> [1,-1],  
-			sync						=> [1,-10],
-			float						=> [1,-1,1,-1],
-			end							=> [1,-40],
-			clockabs				=> -1,			# -1 = auto
-			format					=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble				=> 'i',			# Append to converted message	
-			postamble				=> '00',		# Append to converted message	 	
-			clientmodule    => 'IT',
-			modulematch     => '^i......',
-			length_min      => '32',
-			length_max      => '34',		# Don't know maximal lenth of a valid message
-			postDemodulation => \&SIGNALduino_bit2Arctec,
+			name							=> 'arctech / intertechno',
+			id								=> '17',
+			one								=> [1,-5,1,-1],
+			zero							=> [1,-1,1,-5],
+			#one							=> [1,-5],
+			#zero							=> [1,-1],
+			sync							=> [1,-10],
+			float							=> [1,-1,1,-1],
+			end								=> [1,-40],
+			clockabs						=> -1,				# -1 = auto
+			format						=> 'twostate',	# tristate can't be migrated from bin into hex!
+			preamble					=> 'i',					# Append to converted message
+			postamble					=> '00',				# Append to converted message
+			clientmodule			=> 'IT',
+			modulematch				=> '^i......',
+			length_min				=> '32',
+			length_max				=> '34',				# Don't know maximal lenth of a valid message
+			postDemodulation	=> \&SIGNALduino_bit2Arctec,
 		},
 	"17.1"	=> # intertechno --> MU anstatt sonst MS (ID 17)
 			# MU;P0=344;P1=-1230;P2=-200;D=01020201020101020102020102010102010201020102010201020201020102010201020101020102020102010201020102010201010200;CP=0;R=0;
@@ -443,8 +443,8 @@
 			zero						=> [1,-1,1,-5],
 			clockabs				=> 230,			# -1 = auto
 			format					=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble				=> 'i',			# Append to converted message	
-			postamble				=> '00',		# Append to converted message	 	
+			preamble				=> 'i',			# Append to converted message
+			postamble				=> '00',		# Append to converted message
 			clientmodule    => 'IT',
 			modulematch     => '^i......',
 			length_min      => '32',
@@ -454,17 +454,17 @@
 	"18"	=>	## Oregon Scientific v1
 						# MC;LL=-2721;LH=3139;SL=-1246;SH=1677;D=1A51FF47;C=1463;L=32;R=12;
 		{
-			name						=> 'OSV1',	
+			name						=> 'OSV1',
 			id							=> '18',
-			clockrange     	=> [1400,1500],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			preamble				=> '',					
-			clientmodule    => 'OREGON',
-			modulematch     => '^[0-9A-F].*',
-			length_min      => '32',
-			length_max      => '32',
-			polarity        => 'invert',		    # invert bits
-			method          => \&SIGNALduino_OSV1   # Call to process this message
+			clockrange			=> [1400,1500],					# min , max
+			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
+			preamble				=> '',
+			clientmodule		=> 'OREGON',
+			modulematch			=> '^[0-9A-F].*',
+			length_min			=> '32',
+			length_max			=> '32',
+			polarity				=> 'invert',						# invert bits
+			method					=> \&SIGNALduino_OSV1		# Call to process this message
 		},
 	"19" => # minify Funksteckdose
 					# https://github.com/RFD-FHEM/RFFHEM/issues/114
@@ -477,58 +477,58 @@
 			one						=> [3,-1],
 			zero					=> [1,-3],
 			clockabs			=> 300,
-			format				=> 'twostate',	  		
+			format				=> 'twostate',
 			preamble			=> 'u19#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '19',
-			length_max		=> '23',				# not confirmed, length one more as MU Message
-		}, 	 	
-	"20" => # Livolo
-         	# https://github.com/RFD-FHEM/RFFHEM/issues/29
-         	# MU;P0=-195;P1=151;P2=475;P3=-333;D=0101010101 02 01010101010101310101310101010101310101 02 01010101010101010101010101010101010101 02 01010101010101010101010101010101010101 02 010101010101013101013101;CP=1;
-         	#
-         	# protocol sends 24 to 47 pulses per message.
-         	# First pulse is the header and is 595 μs long. All subsequent pulses are either 170 μs (short pulse) or 340 μs (long pulse) long.
-         	# Two subsequent short pulses correspond to bit 0, one long pulse corresponds to bit 1. There is no footer. The message is repeated for about 1 second.
-         	#             _____________                 ___                 _______
-         	# Start bit: |             |___|    bit 0: |   |___|    bit 1: |       |___|
+			length_max		=> '23',					# not confirmed, length one more as MU Message
+		},
+	"20"	=>	# Livolo
+						# https://github.com/RFD-FHEM/RFFHEM/issues/29
+						# MU;P0=-195;P1=151;P2=475;P3=-333;D=0101010101 02 01010101010101310101310101010101310101 02 01010101010101010101010101010101010101 02 01010101010101010101010101010101010101 02 010101010101013101013101;CP=1;
+						#
+						# protocol sends 24 to 47 pulses per message.
+						# First pulse is the header and is 595 μs long. All subsequent pulses are either 170 μs (short pulse) or 340 μs (long pulse) long.
+						# Two subsequent short pulses correspond to bit 0, one long pulse corresponds to bit 1. There is no footer. The message is repeated for about 1 second.
+						#             _____________                 ___                 _______
+						# Start bit: |             |___|    bit 0: |   |___|    bit 1: |       |___|
 		{
-			name					=> 'livolo',	
+			name					=> 'livolo',
 			id          	=> '20',
 			one						=> [3],
 			zero					=> [1],
-			start					=> [5],				
-			clockabs			=> 110,                  #can be 90-140
-			format				=> 'twostate',	  		
-			preamble			=> 'u20#',				# prepend to converted message	
+			start					=> [5],
+			clockabs			=> 110,						#can be 90-140
+			format				=> 'twostate',
+			preamble			=> 'u20#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '16',
-			#length_max		=> '',					# missing
+			#length_max		=> '',						# missing
 			filterfunc		=> 'SIGNALduino_filterSign',
 		},
-	"21" => # Einhell Garagentor	
-	        # https://forum.fhem.de/index.php?topic=42373.0 | user have no RAWMSG
-	        # static adress: Bit 1-28 | channel remote Bit 29-32 | repeats 31 | pause 20 ms
-	        # Channelvalues dez
-	        # 1 left 1x kurz | 2 left 2x kurz | 3 left 3x kurz | 5 right 1x kurz | 6 right 2x kurz | 7 right 3x kurz ... gedrückt
+	"21"	=>	# Einhell Garagentor
+						# https://forum.fhem.de/index.php?topic=42373.0 | user have no RAWMSG
+						# static adress: Bit 1-28 | channel remote Bit 29-32 | repeats 31 | pause 20 ms
+						# Channelvalues dez
+						# 1 left 1x kurz | 2 left 2x kurz | 3 left 3x kurz | 5 right 1x kurz | 6 right 2x kurz | 7 right 3x kurz ... gedrückt
 		{
-			name						=> 'Einhell Garagedoor',	
+			name						=> 'Einhell Garagedoor',
 			comment         => 'remote ISC HS 434/6',
 			id							=> '21',
 			one							=> [-3,1],
 			zero						=> [-1,3],
-			#sync						=> [-50,1],	
-			start						=> [-50,1],	
-			clockabs				=> 400,                  #ca 400us
-			format					=> 'twostate',	  		
-			preamble				=> 'u21#',				# prepend to converted message	
+			#sync						=> [-50,1],
+			start						=> [-50,1],
+			clockabs				=> 400,					#ca 400us
+			format					=> 'twostate',
+			preamble				=> 'u21#',			# prepend to converted message
 			#clientmodule   => '',
 			#modulematch    => '',
 			length_min      => '32',
-			length_max      => '32',				
-			paddingbits     => '1',					# This will disable padding 
+			length_max      => '32',
+			paddingbits     => '1',					# This will disable padding
 		},
 	"22" => ## HAMULiGHT LED Trafo
 					# https://forum.fhem.de/index.php?topic=89301.0
@@ -551,24 +551,24 @@
 			},
 	"23" => # Pearl Sensor
 		{
-			name					=> 'perl unknown',	
+			name					=> 'perl unknown',
 			id						=> '23',
 			one						=> [1,-6],
 			zero					=> [1,-1],
-			sync					=> [1,-50],				
+			sync					=> [1,-50],
 			clockabs			=> 200,						#ca 200us
-			format				=> 'twostate',	  		
-			preamble			=> 'u23#',				# prepend to converted message	
+			format				=> 'twostate',
+			preamble			=> 'u23#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '36',
-			length_max		=> '44',				
+			length_max		=> '44',
 		},
 	"24" =>	# visivon
 					# https://github.com/RFD-FHEM/RFFHEM/issues/39
 					# MU;P0=132;P1=500;P2=-233;P3=-598;P4=-980;P5=4526;D=012120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030303120303030453120303121212121203121212121203121212121212030303030312030312031203030303030312031203031212120303030;CP=0;O;
 		{
-			name					=> 'visivon remote',	
+			name					=> 'visivon remote',
 			id          	=> '24',
 			one						=> [3,-2],
 			zero					=> [1,-5],
@@ -576,119 +576,119 @@
 			#zero					=> [1,-1],
 			start					=> [30,-5],
 			clockabs			=> 150,						#ca 150us
-			format				=> 'twostate',	  		
-			preamble			=> 'u24#',				# prepend to converted message	
+			format				=> 'twostate',
+			preamble			=> 'u24#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '54',
-			length_max		=> '58',				
+			length_max		=> '58',
 		},
 	"25" => # LES remote for led lamp
 					# https://github.com/RFD-FHEM/RFFHEM/issues/40
 					# MS;P0=-376;P1=697;P2=-726;P3=322;P4=-13188;P5=-15982;D=3530123010101230123230123010101010101232301230123234301230101012301232301230101010101012323012301232;CP=3;SP=5;O;
 		{
-			name					=> 'les led remote',	
+			name					=> 'les led remote',
 			id						=> '25',
 			one						=> [-2,1],
 			zero					=> [-1,2],
 			sync					=> [-46,1],				# this is a end marker, but we use this as a start marker
-			clockabs			=> 350,                 #ca 350us
-			format				=> 'twostate',	  		
-			preamble			=> 'u25#',				# prepend to converted message	
+			clockabs			=> 350,						#ca 350us
+			format				=> 'twostate',
+			preamble			=> 'u25#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '24',
-			length_max		=> '50',				# message has only 24 bit, but we get more than one message, calculation has to be corrected
+			length_max		=> '50',					# message has only 24 bit, but we get more than one message, calculation has to be corrected
 		},
 	"26" => # some remote code send by flamingo style remote controls
 					# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
 					# MU;P0=1086;P1=-433;P2=327;P3=-1194;P4=-2318;P5=2988;D=01012323010123010101230123012323232323010101232324010123230101230101012301230123232323230101012323240101232301012301010123012301232323232301010123232401012323010123010101230123012323232323010101232353;CP=2;
 		{
-			name					=> 'remote26',	
+			name					=> 'remote26',
 			id						=> '26',
 			one						=> [1,-3],
 			zero					=> [3,-1],
 			# sync				=> [1,-6],				# Message is not provided as MS, due to small fact
 			start					=> [1,-6],				# Message is not provided as MS, due to small fact
-			clockabs			=> 380,           #ca 380
-			format				=> 'twostate',	  		
-			preamble			=> 'u26#',				# prepend to converted message	
+			clockabs			=> 380,						#ca 380
+			format				=> 'twostate',
+			preamble			=> 'u26#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '24',
-			length_max		=> '24',				# message has only 24 bit, but we get more than one message, calculation has to be corrected
+			length_max		=> '24',					# message has only 24 bit, but we get more than one message, calculation has to be corrected
 		},
 	"27" => # some remote code, send by flamingo style remote controls
 					# https://forum.fhem.de/index.php/topic,43292.msg352982.html#msg352982
 					# MU;P0=963;P1=-559;P2=393;P3=-1134;P4=2990;P5=-7172;D=01012323010123010101230123012323232323010101232345010123230101230101012301230123232323230101012323450101232301012301010123012301232323232301010123234501012323010123010101230123012323232323010101232323;CP=2;
 		{
-			name						=> 'remote27',	
+			name						=> 'remote27',
 			id							=> '27',
 			one							=> [1,-2],
 			zero						=> [2,-1],
 			start						=> [6,-15],				# Message is not provided as MS, worakround is start
-			clockabs				=> 480,                 #ca 480
-			format					=> 'twostate',	  		
-			preamble				=> 'u27#',				# prepend to converted message	
-			#clientmodule    => '',
-			#modulematch     => '',
-			length_min      => '24',
-			length_max      => '24',				
+			clockabs				=> 480,						#ca 480
+			format					=> 'twostate',
+			preamble				=> 'u27#',				# prepend to converted message
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '24',
+			length_max			=> '24',
 		},
 	"28" => # some remote code, send by aldi IC Ledspots
 		{
-			name						=> 'IC Ledspot',	
+			name						=> 'IC Ledspot',
 			id							=> '28',
 			one							=> [1,-1],
 			zero						=> [1,-2],
-			start						=> [4,-5],				
-			clockabs				=> 600,                 #ca 600
-			format					=> 'twostate',	  		
+			start						=> [4,-5],
+			clockabs				=> 600,						#ca 600
+			format					=> 'twostate',
 			preamble				=> 'u28#',				# prepend to converted message
-			#clientmodule    => '',
-			#modulematch     => '',
-			length_min      => '8',
-			length_max      => '8',				
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '8',
+			length_max			=> '8',
 		},
 	"29" => # example remote control with HT12E chip
 					# MU;P0=250;P1=-492;P2=166;P3=-255;P4=491;P5=-8588;D=052121212121234121212121234521212121212341212121212345212121212123412121212123452121212121234121212121234;CP=0;
 					# https://forum.fhem.de/index.php/topic,58397.960.html
 		{
-			name						=> 'HT12e remote',	
-			comment         => 'Remote control for example Westinghouse airfan with five Buttons (developModule SD_UT is only in github available)',
+			name						=> 'HT12e remote',
+			comment					=> 'Remote control for example Westinghouse airfan with five Buttons (developModule SD_UT is only in github available)',
 			id							=> '29',
 			one							=> [-2,1],
 			zero						=> [-1,2],
-			start           => [-35,1],         # Message is not provided as MS, worakround is start
-			clockabs        => 235,             # ca 220
-			format          => 'twostate',      # there is a pause puls between words
-			preamble        => 'P29#',				# prepend to converted message	
-			clientmodule    => 'SD_UT', 
-			modulematch     => '^P29#.{3}',
-			length_min      => '12',
-			length_max      => '12',
+			start						=> [-35,1],				# Message is not provided as MS, worakround is start
+			clockabs				=> 235,						# ca 220
+			format					=> 'twostate',		# there is a pause puls between words
+			preamble				=> 'P29#',				# prepend to converted message
+			clientmodule		=> 'SD_UT', 
+			modulematch			=> '^P29#.{3}',
+			length_min			=> '12',
+			length_max			=> '12',
 		},
 	 "30" => 	# a unitec remote door reed switch
 						# https://forum.fhem.de/index.php?topic=43346.0
 						# MU;P0=-10026;P1=-924;P2=309;P3=-688;P4=-361;P5=637;D=123245453245324532453245320232454532453245324532453202324545324532453245324532023245453245324532453245320232454532453245324532453202324545324532453245324532023245453245324532453245320232454532453245324532453202324545324532453245324532023240;CP=2;O;
 						# MU;P0=307;P1=-10027;P2=-691;P3=-365;P4=635;D=0102034342034203420342034201020343420342034203420342010203434203420342034203420102034342034203420342034201020343420342034203420342010203434203420342034203420102034342034203420342034201;CP=0;
 		{
-			name					=> 'diverse',	
+			name					=> 'diverse',
 			comment				=> 'unitec remote door reed switch 47031 (developModule SD_UT module is only in github available)',
-			id          	=> '30',
+			id						=> '30',
 			one						=> [-2,1],
 			zero					=> [-1,2],
 			start					=> [-30,1],				# Message is not provided as MS, worakround is start
-			clockabs			=> 330,           # ca 300 us
-			format				=> 'twostate',	  # there is a pause puls between words
-			preamble			=> 'P30#',				# prepend to converted message	
+			clockabs			=> 330,						# ca 300 us
+			format				=> 'twostate',		# there is a pause puls between words
+			preamble			=> 'P30#',				# prepend to converted message
 			clientmodule	=> 'SD_UT', 
 			modulematch		=> '^P30#.{3}',
 			length_min		=> '12',
 			length_max		=> '12',				# message has only 10 bit but is paddet to 12
 		},
 	"31" => # Pollin Isotronik - 12 Tasten remote
-			# https://github.com/RFD-FHEM/RFFHEM/issues/44            
+			# https://github.com/RFD-FHEM/RFFHEM/issues/44
 			# OLD
 			# MU;P0=-32001;P1=1208;P2=-682;P3=-1324;P4=570;P5=-15617;D=12121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213454212121212121212121212121212121342121213405;CP=1;
 			# NEW
@@ -698,17 +698,17 @@
 		{
 			name					=> 'Pollin Isotronik',
 			comment				=> 'remote',
-			id          	=> '31',
+			id						=> '31',
 			one						=> [-1,2],
 			zero					=> [-2,1],
-			start					=> [-18,1],				
-			clockabs			=> 600,                  
-			format				=> 'twostate',	  		
-			preamble			=> 'u31#',				# prepend to converted message	
+			start					=> [-18,1],
+			clockabs			=> 600,
+			format				=> 'twostate',
+			preamble			=> 'u31#',				# prepend to converted message
 			#clientmodule	=> '',
 			#modulematch	=> '',
 			length_min		=> '19',
-			length_max		=> '20',				
+			length_max		=> '20',
 		},
 	"32" => # FreeTec PE-6946 -> http://www.free-tec.de/Funkklingel-mit-Voic-PE-6946-919.shtml
 			# OLD
@@ -720,48 +720,48 @@
 			# MU;P0=146;P1=245;P3=571;P4=-708;P5=-284;P7=-6689;D=14351435143514143535353535353535353535350704040435043504350435040435353535353535353535353507040404350435043504350404353535353535353535353535070404043504350435043504043535353535353535353535350704040435043504350435040435353535353535353535353507040404350435;CP=3;R=0;O;
 			# MU;P0=-6680;P1=162;P2=-298;P4=253;P5=-699;P6=555;D=45624562456245456262626262626262626262621015151562156215621562151562626262626262626262626210151515621562156215621515626262626262626262626262;CP=6;R=0;
 		{   
-			name						=> 'freetec 6946',	
-			comment         => 'Doorbell FreeTec PE-6946',
+			name						=> 'freetec 6946',
+			comment					=> 'Doorbell FreeTec PE-6946',
 			id							=> '32',
 			one							=> [4,-2],
 			zero						=> [1,-5],
-			start           => [1,-45],				# neuerdings MU Erknnung
-			#sync           => [1,-49],				# old MS Erkennung
+			start						=> [1,-45],				# neuerdings MU Erknnung
+			#sync						=> [1,-49],				# old MS Erkennung
 			clockabs				=> 150,
-			format					=> 'twostate',	  		
-			preamble				=> 'P32#',				# prepend to converted message	
-			clientmodule    => 'SD_BELL',
-			modulematch     => '^P32#.*',
-			length_min      => '24',
-			length_max      => '24',				
+			format					=> 'twostate',
+			preamble				=> 'P32#',				# prepend to converted message
+			clientmodule		=> 'SD_BELL',
+			modulematch			=> '^P32#.*',
+			length_min			=> '24',
+			length_max			=> '24',
 		},
-    "33" => # Thermo-/Hygrosensor S014, renkforce E0001PA, Conrad S522, TX-EZ6 (Weatherstation TZS First Austria)
-            # https://forum.fhem.de/index.php?topic=35844.0																													 
-            # MS;P0=-7871;P2=-1960;P3=578;P4=-3954;D=030323232323434343434323232323234343434323234343234343234343232323432323232323232343234;CP=3;SP=0;R=0;m=0;
-            # sensor id=62, channel=1, temp=21.1, hum=76, bat=ok
+	"33"	=>	# Thermo-/Hygrosensor S014, renkforce E0001PA, Conrad S522, TX-EZ6 (Weatherstation TZS First Austria)
+						# https://forum.fhem.de/index.php?topic=35844.0
+						# MS;P0=-7871;P2=-1960;P3=578;P4=-3954;D=030323232323434343434323232323234343434323234343234343234343232323432323232323232343234;CP=3;SP=0;R=0;m=0;
+						# sensor id=62, channel=1, temp=21.1, hum=76, bat=ok
 						# !! ToDo Tx-EZ6 neues Attribut ins Modul bauen um Trend + CRC auszuwerten !!
-    {   
-      name					=> 'weather33',		
+		{
+			name					=> 'weather33',
 			comment				=> 'S014/TFA 30.3200/TCM/Conrad S522/renkforce E0001PA/Tx-EZ6',
 			id						=> '33',
 			one						=> [1,-8],
 			zero					=> [1,-4],
 			sync					=> [1,-16],
-			clockabs   		=> '500',
-			format     		=> 'twostate',	# not used now
-			preamble			=> 'W33#',			# prepend to converted message	
-			postamble			=> '',					# Append to converted message	 	
+			clockabs			=> '500',
+			format				=> 'twostate',	# not used now
+			preamble			=> 'W33#',			# prepend to converted message
+			postamble			=> '',					# Append to converted message
 			clientmodule	=> 'SD_WS',
 			#modulematch	=> '',
 			length_min		=> '42',
 			length_max		=> '44',
-    },
-    "34" => # QUIGG GT-7000 Funk-Steckdosendimmer | transmitter DMV-7000 - receiver DMV-7009AS
+		},
+	"34"	=>	# QUIGG GT-7000 Funk-Steckdosendimmer | transmitter DMV-7000 - receiver DMV-7009AS
 						# https://github.com/RFD-FHEM/RFFHEM/issues/195 | https://forum.fhem.de/index.php/topic,38831.msg361341.html#msg361341
 						# MU;P0=-5284;P1=583;P2=-681;P3=1216;P4=-1319;D=012341412323232341412341412323234123232341;CP=1;R=16; | MU;P0=-9812;P1=589;P2=-671;P3=1261;P4=-1320;D=012341412323232341412341412323232323232323;CP=3;R=19;
-            # MU;P0=-9832;P1=577;P2=-670;P3=1219;P4=-1331;D=012341412323232341412341414123234123234141;CP=1;R=16; | MU;P0=-8816;P1=594;P2=-662;P3=1263;P4=-1330;D=012341412323232341412341414123232323234123;CP=1;R=16;
+						# MU;P0=-9832;P1=577;P2=-670;P3=1219;P4=-1331;D=012341412323232341412341414123234123234141;CP=1;R=16; | MU;P0=-8816;P1=594;P2=-662;P3=1263;P4=-1330;D=012341412323232341412341414123232323234123;CP=1;R=16;
 						# MU;P0=-677;P1=581;P2=1250;P3=-1319;D=010231310202020231310231310231023102020202;CP=1;R=18; | MU;P0=-29120;P1=603;P2=-666;P3=1235;P4=-1307;D=012341412323232341412341412341232323232341;CP=1;R=16;
-		{   
+		{
 			name					=> 'QUIGG_GT-7000',
 			comment				=> 'remote QUIGG DMV-7000',
 			id						=> '34',
@@ -769,90 +769,90 @@
 			zero					=> [-2,1],
 			start					=> [1],
 			pause					=> [-15],   # 9900
-			clockabs   		=> '660',
+			clockabs			=> '660',
 			format				=> 'twostate', 
 			preamble			=> 'P34#',
 			clientmodule	=> 'SD_UT',
-			#modulematch 	=> '',
-			length_min 		=> '20',
-			length_max 		=> '20',
+			#modulematch	=> '',
+			length_min		=> '20',
+			length_max		=> '20',
 		},
 	"35" => # Homeeasy
 					# MS;P0=907;P1=-376;P2=266;P3=-1001;P6=-4860;D=2601010123230123012323230101012301230101010101230123012301;CP=2;SP=6;
-		{   
+		{
 			name							=> 'HE800',
-			comment						=> 'Homeeasy',	
+			comment						=> 'Homeeasy',
 			id								=> '35',
 			one								=> [1,-4],
 			zero							=> [3.4,-1],
 			sync							=> [1,-18],
 			clockabs					=> '280',		
-			format						=> 'twostate',  		# not used now
-			preamble					=> 'ih',				# prepend to converted message	
-			postamble					=> '',					# Append to converted message	 	
+			format						=> 'twostate',		# not used now
+			preamble					=> 'ih',					# prepend to converted message
+			postamble					=> '',						# Append to converted message
 			clientmodule			=> 'IT',
-			#modulematch     => '',
+			#modulematch			=> '',
 			length_min				=> '28',
 			length_max				=> '40',
 			postDemodulation	=> \&SIGNALduino_HE800,
-    	},
+		},
 	"36" =>
-		{   
-			name						=> 'socket36',		
+		{
+			name						=> 'socket36',
 			id							=> '36',
 			one							=> [1,-3],
 			zero						=> [1,-1],
 			start						=> [20,-20],
 			clockabs				=> '500',		
-			format					=> 'twostate',  		# not used now
-			preamble				=> 'u36#',				# prepend to converted message	
-			postamble				=> '',					# Append to converted message	 	
-			#clientmodule    => '',
-			#modulematch     => '',
-			length_min      => '24',
-			length_max      => '24',
+			format					=> 'twostate',		# not used now
+			preamble				=> 'u36#',				# prepend to converted message
+			postamble				=> '',						# Append to converted message
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '24',
+			length_max			=> '24',
 		},
-    "37" =>	## Bresser 7009994
+	"37"	=>	## Bresser 7009994
 						# MU;P0=729;P1=-736;P2=483;P3=-251;P4=238;P5=-491;D=010101012323452323454523454545234523234545234523232345454545232345454545452323232345232340;CP=4;
 						# MU;P0=-790;P1=-255;P2=474;P4=226;P6=722;P7=-510;D=721060606060474747472121212147472121472147212121214747212147474721214747212147214721212147214060606060474747472121212140;CP=4;R=216;
 						# short pulse of 250 us followed by a 500 us gap is a 0 bit
 						# long pulse of 500 us followed by a 250 us gap is a 1 bit
 						# sync preamble of pulse, gap, 750 us each, repeated 4 times
-	{   
-			name						=> 'Bresser 7009994',		
+	{
+			name						=> 'Bresser 7009994',
 			id							=> '37',
 			one							=> [2,-1],
 			zero						=> [1,-2],
 			start						=> [3,-3,3,-3],
 			clockabs				=> '250',		
-			format					=> 'twostate',  		# not used now
-			preamble				=> 'W37#',				# prepend to converted message	
-			clientmodule    => 'SD_WS', 
-			length_min      => '40',
-			length_max      => '41',
+			format					=> 'twostate',		# not used now
+			preamble				=> 'W37#',				# prepend to converted message
+			clientmodule		=> 'SD_WS', 
+			length_min			=> '40',
+			length_max			=> '41',
 	},
-    "38" => ## Lidl Wetterstation
-         	# https://github.com/RFD-FHEM/RFFHEM/issues/63
-         	# MS;P1=367;P2=-2077;P4=-9415;P5=-4014;D=141515151515151515121512121212121212121212121212121212121212121212;CP=1;SP=4;O;
-		{   
-			name						=> 'weather38',		
+	"38"	=>	## Lidl Wetterstation
+						# https://github.com/RFD-FHEM/RFFHEM/issues/63
+						# MS;P1=367;P2=-2077;P4=-9415;P5=-4014;D=141515151515151515121512121212121212121212121212121212121212121212;CP=1;SP=4;O;
+		{
+			name						=> 'weather38',
 			id          		=> '38',
 			one							=> [1,-10],
 			zero						=> [1,-5],
 			sync						=> [1,-25],
-			clockabs   			=> '360',
-			format     			=> 'twostate',  # not used now
-			preamble				=> 's',			# prepend to converted message	 	
-			postamble				=> '00',		# Append to converted message	 	
-			clientmodule    => 'CUL_TCM97001',
-			#modulematch     => '^s[A-Fa-f0-9]+',
-			length_min      => '32',
-			length_max      => '32',
-			paddingbits     => '8',			
-		},   
-	"39" => ## X10 Protocol
-         	# https://github.com/RFD-FHEM/RFFHEM/issues/65
-         	# MU;P0=10530;P1=-2908;P2=533;P3=-598;P4=-1733;P5=767;D=0123242323232423242324232324232423242323232324232323242424242324242424232423242424232501232423232324232423242323242324232423232323242323232424242423242424242324232424242325012324232323242324232423232423242324232323232423232324242424232424242423242324242;CP=2;O;
+			clockabs				=> '360',
+			format					=> 'twostate',		# not used now
+			preamble				=> 's',						# prepend to converted message
+			postamble				=> '00',					# Append to converted message
+			clientmodule		=> 'CUL_TCM97001',
+			#modulematch		=> '^s[A-Fa-f0-9]+',
+			length_min			=> '32',
+			length_max			=> '32',
+			paddingbits			=> '8',
+		},
+	"39"	=>	## X10 Protocol
+						# https://github.com/RFD-FHEM/RFFHEM/issues/65
+						# MU;P0=10530;P1=-2908;P2=533;P3=-598;P4=-1733;P5=767;D=0123242323232423242324232324232423242323232324232323242424242324242424232423242424232501232423232324232423242323242324232423232323242323232424242423242424242324232424242325012324232323242324232423232423242324232323232423232324242424232424242423242324242;CP=2;O;
 		{
 			name							=> 'X10 Protocol',
 			id								=> '39',
@@ -867,34 +867,34 @@
 			length_min				=> '32',
 			length_max				=> '44',
 			paddingbits				=> '8',		
-			postDemodulation	=> \&SIGNALduino_lengtnPrefix,			
+			postDemodulation	=> \&SIGNALduino_lengtnPrefix,
 			filterfunc				=> 'SIGNALduino_compPattern',
-		},    
-	"40" => ## Romotec
-			# https://github.com/RFD-FHEM/RFFHEM/issues/71
-			# MU;P0=300;P1=-772;P2=674;P3=-397;P4=4756;P5=-1512;D=4501232301230123230101232301010123230101230103;CP=0;
-			# MU;P0=-132;P1=-388;P2=675;P4=271;P5=-762;D=012145212145452121454545212145452145214545454521454545452145454541;CP=4;
+		},
+	"40"	=>	## Romotec
+						# https://github.com/RFD-FHEM/RFFHEM/issues/71
+						# MU;P0=300;P1=-772;P2=674;P3=-397;P4=4756;P5=-1512;D=4501232301230123230101232301010123230101230103;CP=0;
+						# MU;P0=-132;P1=-388;P2=675;P4=271;P5=-762;D=012145212145452121454545212145452145214545454521454545452145454541;CP=4;
 		{
-			name          => 'romotec',
-			id            => '40',
-			one           => [3,-2],
-			zero          => [1,-3],
-			start         => [1,-2],
-			clockabs      => 250, 
-			preamble      => 'u40#', # prepend to converted message
-			#clientmodule => '',
-			#modulematch => '',
-			length_min    => '12',
-			#length_max   => '',     # missing
-		},    
-	"41" => ## Elro (Smartwares) Doorbell DB200 / 16 melodies
-					# https://github.com/RFD-FHEM/RFFHEM/issues/70
-					# MS;P0=-526;P1=1450;P2=467;P3=-6949;P4=-1519;D=231010101010242424242424102424101010102410241024101024241024241010;CP=2;SP=3;O;
-					# MS;P0=468;P1=-1516;P2=1450;P3=-533;P4=-7291;D=040101230101010123230101232323012323010101012301232323012301012323;CP=0;SP=4;O;
-					# unitec Modell:98156+98YK / 36 melodies
-					# repeats 15, change two codes every 15 repeats --> one button push, 2 codes
-					# MS;P0=1474;P1=-521;P2=495;P3=-1508;P4=-6996;D=242323232301232323010101230123232301012301230123010123230123230101;CP=2;SP=4;R=51;m=0;
-					# MS;P1=-7005;P2=482;P3=-1511;P4=1487;P5=-510;D=212345454523452345234523232345232345232323234523454545234523234545;CP=2;SP=1;R=47;m=2;
+			name						=> 'romotec',
+			id							=> '40',
+			one							=> [3,-2],
+			zero						=> [1,-3],
+			start						=> [1,-2],
+			clockabs				=> 250, 
+			preamble				=> 'u40#',	# prepend to converted message
+			#clientmodule		=> '',
+			#modulematch		=> '',
+			length_min			=> '12',
+			#length_max			=> '',			# missing
+		},
+	"41"	=>	## Elro (Smartwares) Doorbell DB200 / 16 melodies
+						# https://github.com/RFD-FHEM/RFFHEM/issues/70
+						# MS;P0=-526;P1=1450;P2=467;P3=-6949;P4=-1519;D=231010101010242424242424102424101010102410241024101024241024241010;CP=2;SP=3;O;
+						# MS;P0=468;P1=-1516;P2=1450;P3=-533;P4=-7291;D=040101230101010123230101232323012323010101012301232323012301012323;CP=0;SP=4;O;
+						# unitec Modell:98156+98YK / 36 melodies
+						# repeats 15, change two codes every 15 repeats --> one button push, 2 codes
+						# MS;P0=1474;P1=-521;P2=495;P3=-1508;P4=-6996;D=242323232301232323010101230123232301012301230123010123230123230101;CP=2;SP=4;R=51;m=0;
+						# MS;P1=-7005;P2=482;P3=-1511;P4=1487;P5=-510;D=212345454523452345234523232345232345232323234523454545234523234545;CP=2;SP=1;R=47;m=2;
 		{
 			name					=> 'Doorbell',
 			comment				=> 'Elro (Smartwares) DB200 / unitec',
@@ -908,127 +908,126 @@
 			modulematch		=> '^P41#.*',
 			length_min		=> '32',
 			length_max		=> '32',
-		},     
-	"42" => ## KANGTAI Doorbell (Pollin 94-550405)
-			# https://github.com/RFD-FHEM/RFFHEM/issues/365
-			# MS;P0=1390;P1=-600;P2=409;P3=-1600;P4=-7083;D=240123010101230123232301230123232301232323230123010101230123230101;CP=2;SP=4;R=248;O;m0;
-			# MS;P0=1399;P1=-604;P2=397;P3=-1602;P4=-7090;D=240123010101230123232301230123232301232323230123010101230123230101;CP=2;SP=4;R=248;O;m1;
-			# MS;P1=403;P2=-7102;P3=-1608;P4=1378;P5=-620;D=121313134513454545451313451313134545451345134513454513134513134545;CP=1;SP=2;R=5;O;m0;
-		{
-			name         => 'KANGTAI',
-			comment      => 'KANGTAI Doorbell (Pollin 94-550405)',
-			id           => '42',
-			one					 => [1,-4],   # 400,-1600
-			zero				 => [4,-1],   # 1600,-600
-			sync         => [1,-17],  # 400,-7000
-			clockabs     => 400,
-			format       => 'twostate',
-			preamble     => 'P42#',
-			clientmodule => 'SD_Bell',
-			modulematch  => '^P42#.*',
-			length_min   => '32',
-			length_max   => '32',
 		},
-	"43" => ## Somfy RTS
-					# MC;LL=-1405;LH=1269;SL=-723;SH=620;D=98DBD153D631BB;C=669;L=56;R=229;
+	"42"	=>	## KANGTAI Doorbell (Pollin 94-550405)
+						# https://github.com/RFD-FHEM/RFFHEM/issues/365
+						# MS;P0=1390;P1=-600;P2=409;P3=-1600;P4=-7083;D=240123010101230123232301230123232301232323230123010101230123230101;CP=2;SP=4;R=248;O;m0;
+						# MS;P0=1399;P1=-604;P2=397;P3=-1602;P4=-7090;D=240123010101230123232301230123232301232323230123010101230123230101;CP=2;SP=4;R=248;O;m1;
+						# MS;P1=403;P2=-7102;P3=-1608;P4=1378;P5=-620;D=121313134513454545451313451313134545451345134513454513134513134545;CP=1;SP=2;R=5;O;m0;
+		{
+			name					=> 'KANGTAI',
+			comment				=> 'KANGTAI Doorbell (Pollin 94-550405)',
+			id						=> '42',
+			one						=> [1,-4],   # 400,-1600
+			zero					=> [4,-1],   # 1600,-600
+			sync					=> [1,-17],  # 400,-7000
+			clockabs			=> 400,
+			format				=> 'twostate',
+			preamble			=> 'P42#',
+			clientmodule	=> 'SD_Bell',
+			modulematch		=> '^P42#.*',
+			length_min		=> '32',
+			length_max		=> '32',
+		},
+	"43"	=>	## Somfy RTS
+						# MC;LL=-1405;LH=1269;SL=-723;SH=620;D=98DBD153D631BB;C=669;L=56;R=229;
 		{
 			name					=> 'Somfy RTS',
 			id						=> '43',
-			clockrange  	=> [610,680],			# min , max
+			clockrange		=> [610,680],								# min , max
 			format				=> 'manchester', 
 			preamble			=> 'Ys',
-			clientmodule	=> 'SOMFY', # not used now
-			modulematch 	=> '^Ys[0-9A-F]{14}',
-			length_min 		=> '56',
-			length_max 		=> '57',
-			method				=> \&SIGNALduino_SomfyRTS, # Call to process this message
+			clientmodule	=> 'SOMFY',									# not used now
+			modulematch		=> '^Ys[0-9A-F]{14}',
+			length_min		=> '56',
+			length_max		=> '57',
+			method				=> \&SIGNALduino_SomfyRTS,	# Call to process this message
 			msgIntro			=> 'SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;',
 			#msgOutro			=> 'SR;P0=-30415;D=0;',
 			frequency			=> '10AB85550A',
 		},
 	"44" => ## Bresser Temeo Trend
 		{
-       		name					=> 'BresserTemeo',
-       		id						=> '44',
-       		clockabs			=> 500,
-       		zero					=> [4,-4],
-       		one						=> [4,-8],
-       		start					=> [8,-8],
-       		preamble			=> 'W44#',
-       		clientmodule	=> 'SD_WS',
-       		modulematch		=> '^W44#[A-F0-9]{18}',
-       		length_min 		=> '64',
-       		length_max 		=> '72',
+			name					=> 'BresserTemeo',
+			id						=> '44',
+			clockabs			=> 500,
+			zero					=> [4,-4],
+			one						=> [4,-8],
+			start					=> [8,-8],
+			preamble			=> 'W44#',
+			clientmodule	=> 'SD_WS',
+			modulematch		=> '^W44#[A-F0-9]{18}',
+			length_min 		=> '64',
+			length_max 		=> '72',
 		},
-	"44.1" => ## Bresser Temeo Trend
+	"44.1"	=>	## Bresser Temeo Trend
 		{
-       		name 			=> 'BresserTemeo',
-       		id 			=> '44',
-       		clockabs		=> 500,
-       		zero 			=> [4,-4],
-       		one				=> [4,-8],
-       		start 			=> [8,-12],
-       		preamble 		=> 'W44x#',
-       		clientmodule		=> 'SD_WS',
-       		modulematch		=> '^W44x#[A-F0-9]{18}',
-       		length_min 		=> '64',
-       		length_max 		=> '72',
+			name					=> 'BresserTemeo',
+			id						=> '44',
+			clockabs			=> 500,
+			zero					=> [4,-4],
+			one						=> [4,-8],
+			start					=> [8,-12],
+			preamble			=> 'W44x#',
+			clientmodule	=> 'SD_WS',
+			modulematch		=> '^W44x#[A-F0-9]{18}',
+			length_min		=> '64',
+			length_max		=> '72',
 		},
-
-    "45"  => #  Revolt 
-			 #	MU;P0=-8320;P1=9972;P2=-376;P3=117;P4=-251;P5=232;D=012345434345434345454545434345454545454543454343434343434343434343434543434345434343434545434345434343434343454343454545454345434343454345434343434343434345454543434343434345434345454543454343434543454345434545;CP=3;R=2
+	"45"	=>	#  Revolt 
+						#	MU;P0=-8320;P1=9972;P2=-376;P3=117;P4=-251;P5=232;D=012345434345434345454545434345454545454543454343434343434343434343434543434345434343434545434345434343434343454343454545454345434343454345434343434343434345454543434343434345434345454543454343434543454345434545;CP=3;R=2
 		{
-			name         => 'Revolt',
-			id           => '45',
-			one          => [2,-2],
-			zero         => [1,-2],
-			start        => [83,-3], 
-			clockabs     => 120, 
-			preamble     => 'r', # prepend to converted message
-			clientmodule => 'Revolt', 
-			modulematch  => '^r[A-Fa-f0-9]{22}', 
-			length_min   => '84',
-			length_max   => '120',	
-			postDemodulation => sub {	my ($name, @bit_msg) = @_;	my @new_bitmsg = splice @bit_msg, 0,88;	return 1,@new_bitmsg; },
+			name							=> 'Revolt',
+			id								=> '45',
+			one								=> [2,-2],
+			zero							=> [1,-2],
+			start							=> [83,-3],
+			clockabs					=> 120, 
+			preamble					=> 'r', # prepend to converted message
+			clientmodule			=> 'Revolt', 
+			modulematch				=> '^r[A-Fa-f0-9]{22}',
+			length_min				=> '84',
+			length_max				=> '120',
+			postDemodulation	=> sub {	my ($name, @bit_msg) = @_;	my @new_bitmsg = splice @bit_msg, 0,88;	return 1,@new_bitmsg; },
 		},    
-    "46"	=> 	## Berner Garagentorantrieb GA401
-							# remote TEDSEN SKX1MD 433.92 MHz - 1 button | settings via 9 switch on battery compartment
-							# compatible with doors: BERNER SKX1MD, ELKA SKX1MD, TEDSEN SKX1LC, TEDSEN SKX1
-							# https://github.com/RFD-FHEM/RFFHEM/issues/91
-							# door open
-							# MU;P0=-15829;P1=-3580;P2=1962;P3=-330;P4=245;P5=-2051;D=1234523232345234523232323234523234540023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323;CP=2;
-							# door close
-							# MU;P0=-1943;P1=1966;P2=-327;P3=247;P5=-15810;D=01230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230;CP=1;
+	"46"	=>	## Berner Garagentorantrieb GA401
+						# remote TEDSEN SKX1MD 433.92 MHz - 1 button | settings via 9 switch on battery compartment
+						# compatible with doors: BERNER SKX1MD, ELKA SKX1MD, TEDSEN SKX1LC, TEDSEN SKX1
+						# https://github.com/RFD-FHEM/RFFHEM/issues/91
+						# door open
+						# MU;P0=-15829;P1=-3580;P2=1962;P3=-330;P4=245;P5=-2051;D=1234523232345234523232323234523234540023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323232323452323454023452323234523452323;CP=2;
+						# door close
+						# MU;P0=-1943;P1=1966;P2=-327;P3=247;P5=-15810;D=01230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230121212301230121212121230121230351230;CP=1;
 		{
 			name						=> 'Berner Garagedoor GA401',
 			comment					=> 'remote TEDSEN SKX1MD',
 			id							=> '46',
 			one							=> [1,-8],
 			zero						=> [8,-1],
-			start           => [1,-63], 
-			clockabs				=> 250,	# -1=auto	
+			start						=> [1,-63],
+			clockabs				=> 250,	# -1=auto
 			format					=> 'twostate',	# not used now
-			preamble				=> 'P46#',			
-			clientmodule    => 'SD_UT',
-			modulematch     => '^P46#.*',
-			length_min      => '16',
+			preamble				=> 'P46#',
+			clientmodule		=> 'SD_UT',
+			modulematch			=> '^P46#.*',
+			length_min			=> '16',
 			length_max			=> '18',
 		},
 	"47"	=>	## maverick
 						# MC;LL=-507;LH=490;SL=-258;SH=239;D=AA9995599599A959996699A969;C=248;L=104;
 		{
-			name						=> 'Maverick protocol',	
+			name						=> 'Maverick protocol',
 			id							=> '47',
-			clockrange     	=> [180,260],
-			format					=> 'manchester',	
-			preamble				=> 'P47#',						# prepend to converted message	
-			clientmodule    => 'SD_WS_Maverick',   					
-			modulematch     => '^P47#[569A]{12}.*',  					
-			length_min      => '100',
-			length_max      => '108',
-			method          => \&SIGNALduino_Maverick,		# Call to process this message
-			#polarity		=> 'invert'
-		}, 			
+			clockrange			=> [180,260],
+			format					=> 'manchester',
+			preamble				=> 'P47#',						# prepend to converted message
+			clientmodule		=> 'SD_WS_Maverick',
+			modulematch			=> '^P47#[569A]{12}.*',
+			length_min			=> '100',
+			length_max			=> '108',
+			method					=> \&SIGNALduino_Maverick,		# Call to process this message
+			#polarity				=> 'invert'
+		},
 	"48"	=>	## Joker Dostmann TFA 30.3055.01
 						# https://github.com/RFD-FHEM/RFFHEM/issues/92
 						# MU;P0=591;P1=-1488;P2=-3736;P3=1338;P4=-372;P6=-988;D=23406060606063606363606363606060636363636363606060606363606060606060606060606060636060636360106060606060606063606363606363606060636363636363606060606363606060606060606060606060636060636360106060606060606063606363606363606060636363636363606060606363606060;CP=0;O;
@@ -1041,190 +1040,188 @@
 			one							=> [-4,6],
 			zero						=> [-4,2],
 			start						=> [-6,2],
-			format					=> 'twostate',	
-			preamble				=> 'U48#',						# prepend to converted message	
-			#clientmodule    => '',
-			modulematch     => '^U48#.*',
-			length_min      => '47',
-			length_max      => '48',
-		}, 			
+			format					=> 'twostate',
+			preamble				=> 'U48#',						# prepend to converted message
+			#clientmodule		=> '',
+			modulematch			=> '^U48#.*',
+			length_min			=> '47',
+			length_max			=> '48',
+		},
 	"49"	=>	## QUIGG / ALDI GT-9000
 						# https://github.com/RFD-FHEM/RFFHEM/issues/93
 						# MU;P0=-563;P1=479;P2=991;P3=-423;P4=361;P5=-1053;P6=3008;P7=-7110;D=2345454523452323454523452323452323452323454545456720151515201520201515201520201520201520201515151567201515152015202015152015202015202015202015151515672015151520152020151520152020152020152020151515156720151515201520201515201520201520201520201515151;CP=1;R=21;
 		{
-			name						=> 'QUIGG_GT-9000',	
+			name						=> 'QUIGG_GT-9000',
 			id							=> '49',
-			clockabs				=> 400, 						
+			clockabs				=> 400,
 			one							=> [2,-1.2],
 			zero						=> [1,-3],
 			start						=> [6,-15],
-			format					=> 'twostate',	
-			preamble				=> 'U49#',						# prepend to converted message	
-			#clientmodule    => '',
-			modulematch     => '^U49#.*',
-			length_min      => '22',
-			length_max      => '28',
-		}, 
-	"50"    =>	## Opus XT300
-	            # https://github.com/RFD-FHEM/RFFHEM/issues/99
-				# MU;P0=248;P1=-21400;P2=545;P3=-925;P4=1368;P5=-12308;D=01232323232323232343234323432343234343434343234323432343434343432323232323232323232343432323432345232323232323232343234323432343234343434343234323432343434343432323232323232323232343432323432345232323232323232343234323432343234343434343234323432343434343;CP=2;O;
+			format					=> 'twostate',
+			preamble				=> 'U49#',						# prepend to converted message
+			#clientmodule		=> '',
+			modulematch			=> '^U49#.*',
+			length_min			=> '22',
+			length_max			=> '28',
+		},
+	"50"	=>	## Opus XT300
+						# https://github.com/RFD-FHEM/RFFHEM/issues/99
+						# MU;P0=248;P1=-21400;P2=545;P3=-925;P4=1368;P5=-12308;D=01232323232323232343234323432343234343434343234323432343434343432323232323232323232343432323432345232323232323232343234323432343234343434343234323432343434343432323232323232323232343432323432345232323232323232343234323432343234343434343234323432343434343;CP=2;O;
 		{
-			name						=> 'Opus_XT300',	
-			id         		 	=> '50',
-			clockabs    	 	=> 500, 						
+			name						=> 'Opus_XT300',
+			id							=> '50',
+			clockabs				=> 500,
 			zero						=> [3,-2],
 			one							=> [1,-2],
-			#	start			=> [1,-25],						# Wenn das startsignal empfangen wird, fehlt das 1 bit
+			#	start					=> [1,-25],				# Wenn das startsignal empfangen wird, fehlt das 1 bit
 			format					=> 'twostate',	
 			preamble				=> 'W50#',				# prepend to converted message	
-			clientmodule    => 'SD_WS',
-			modulematch     => '^W50#.*',
-			length_min      => '47',
-			length_max      => '48',
+			clientmodule		=> 'SD_WS',
+			modulematch			=> '^W50#.*',
+			length_min			=> '47',
+			length_max			=> '48',
 		},
-	 "51"	=>	# weather sensors
+	"51"	=>	# weather sensors
 						# MS;P0=-16046;P1=552;P2=-1039;P3=983;P5=-7907;P6=-1841;P7=-4129;D=15161716171616161717171716161616161617161717171717171617171617161716161616161616171032323232;CP=1;SP=5;O;
 						# https://github.com/RFD-FHEM/RFFHEM/issues/118
-		{  
+		{
 			name						=> 'weather51',		# Logilink, NC, WS, TCM97001 etc.
 			comment					=> 'IAN 275901 Wetterstation Lidl',
 			id							=> '51',
 			one							=> [1,-8],
 			zero						=> [1,-4],
-			sync						=> [1,-13],		
+			sync						=> [1,-13],
 			clockabs				=> '560',
-			format					=> 'twostate',  # not used now
-			preamble				=> 'W51#',			# prepend to converted message	 	
-			postamble				=> '',					# Append to converted message	 	
-			clientmodule    => 'SD_WS',   
-			modulematch     => '^W51#.*',
-			length_min      => '40',
-			length_max      => '45',
-        },
-    "52"	=>	## Oregon Scientific PIR Protocol
-	            # https://forum.fhem.de/index.php/topic,63604.msg548256.html#msg548256
-							# MC;LL=-1045;LH=1153;SL=-494;SH=606;D=FFFED518;C=549;L=30;
+			format					=> 'twostate',	# not used now
+			preamble				=> 'W51#',			# prepend to converted message
+			postamble				=> '',					# Append to converted message
+			clientmodule		=> 'SD_WS',
+			modulematch			=> '^W51#.*',
+			length_min			=> '40',
+			length_max			=> '45',
+		},
+	"52"	=>	## Oregon Scientific PIR Protocol
+						# https://forum.fhem.de/index.php/topic,63604.msg548256.html#msg548256
+						# MC;LL=-1045;LH=1153;SL=-494;SH=606;D=FFFED518;C=549;L=30;
 		{
-			name						=> 'OS_PIR',	
+			name						=> 'OS_PIR',
 			id							=> '52',
-			clockrange     	=> [470,640],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			clientmodule    => 'OREGON',
-			modulematch     => '^u52#F{3}|0{3}.*',
+			clockrange			=> [470,640],							# min , max
+			format					=> 'manchester',					# tristate can't be migrated from bin into hex!
+			clientmodule		=> 'OREGON',
+			modulematch			=> '^u52#F{3}|0{3}.*',
 			preamble				=> 'u52#',
-			length_min      => '30',
-			length_max      => '30',
-			method          => \&SIGNALduino_OSPIR, # Call to process this message
-			polarity        => 'invert',			
-		}, 	
-    
-	"55"  => ## QUIGG GT-1000
+			length_min			=> '30',
+			length_max			=> '30',
+			method					=> \&SIGNALduino_OSPIR,		# Call to process this message
+			polarity				=> 'invert',
+		},
+	"55"	=> ## QUIGG GT-1000
 		{
 			name						=> 'QUIGG_GT-1000',
 			id							=> '55',
-			clockabs				=> 300, 						
+			clockabs				=> 300,
 			zero						=> [1,-4],
 			one							=> [4,-2],
-			sync						=> [1,-8],						
-			format					=> 'twostate',	
-			preamble				=> 'i',						# prepend to converted message	
-			clientmodule    => 'IT',
-			modulematch     => '^i.*',
-			length_min      => '24',
-			length_max      => '24',
-		},	
+			sync						=> [1,-8],
+			format					=> 'twostate',
+			preamble				=> 'i',						# prepend to converted message
+			clientmodule		=> 'IT',
+			modulematch			=> '^i.*',
+			length_min			=> '24',
+			length_max			=> '24',
+		},
 	"56" => ##  Celexon
 		{
-			name						=> 'Celexon',	
+			name						=> 'Celexon',
 			id							=> '56',
-			clockabs				=> 200, 						
+			clockabs				=> 200,
 			zero						=> [1,-3],
 			one							=> [3,-1],
-			start						=> [25,-3],						
-			format					=> 'twostate',	
-			preamble				=> 'u56#',						# prepend to converted message	
-			#clientmodule    => '',
-			modulematch     => '',
-			length_min      => '56',
-			length_max      => '68',
-		},		
- 	"57" =>	## m-e doorbell fuer FG- und Basic-Serie
+			start						=> [25,-3],
+			format					=> 'twostate',
+			preamble				=> 'u56#',						# prepend to converted message
+			#clientmodule		=> '',
+			modulematch			=> '',
+			length_min			=> '56',
+			length_max			=> '68',
+		},
+	"57" =>	## m-e doorbell fuer FG- und Basic-Serie
 			# https://forum.fhem.de/index.php/topic,64251.0.html
 			# MC;LL=-653;LH=665;SL=-317;SH=348;D=D55B58;C=330;L=21;
 			# MC;LL=-654;LH=678;SL=-314;SH=351;D=D55B58;C=332;L=21;
 			# MC;LL=-653;LH=679;SL=-310;SH=351;D=D55B58;C=332;L=21;
 		{
-			name						=> 'm-e',	
-			comment         => 'radio gong transmitter for FG- and Basic-Serie ',
+			name						=> 'm-e',
+			comment					=> 'radio gong transmitter for FG- and Basic-Serie ',
 			id							=> '57',
-			clockrange     	=> [300,360],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			clientmodule    => 'SD_BELL',
-			modulematch     => '^P57#.*',
+			clockrange			=> [300,360],						# min , max
+			format					=> 'manchester',				# tristate can't be migrated from bin into hex!
+			clientmodule		=> 'SD_BELL',
+			modulematch			=> '^P57#.*',
 			preamble				=> 'P57#',
-			length_min      => '21',
-			length_max      => '24',
-			method          => \&SIGNALduino_MCRAW, # Call to process this message
-			polarity        => 'invert',			
-		}, 	 
-  	"58"	=>	## tfa 30.3208.0 
+			length_min			=> '21',
+			length_max			=> '24',
+			method					=> \&SIGNALduino_MCRAW,	# Call to process this message
+			polarity				=> 'invert',
+		},
+	"58"	=>	## tfa 30.3208.0 
 		{
-			name						=> 'tfa 30.3208.0 ',	
+			name						=> 'tfa 30.3208.0 ',
 			id							=> '58',
-			clockrange     	=> [460,520],			# min , max
-			format					=> 'manchester',	    # tristate can't be migrated from bin into hex!
-			clientmodule    => '',
-			modulematch     => '^W58*',
+			clockrange			=> [460,520],			# min , max
+			format					=> 'manchester',	# tristate can't be migrated from bin into hex!
+			clientmodule		=> '',
+			modulematch			=> '^W58*',
 			preamble				=> 'W58#',
-			length_min      => '54',
-			length_max      => '136',
-			method          => \&SIGNALduino_MCTFA, # Call to process this message
-			polarity        => 'invert',			
-		}, 	 
-	"59" => ##  AK-HD-4 remote | 4 Buttons
-	        # https://github.com/RFD-FHEM/RFFHEM/issues/133
-	        # MU;P0=819;P1=-919;P2=234;P3=-320;P4=8602;P6=156;D=01230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034123030123030123030301212301230123030303030123030341230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034163;CP=0;O;
-	        # MU;P0=-334;P2=8581;P3=237;P4=-516;P5=782;P6=-883;D=23456305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505630505630505056363056305630505050505630505026305056305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505;CP=5;O;
+			length_min			=> '54',
+			length_max			=> '136',
+			method					=> \&SIGNALduino_MCTFA, # Call to process this message
+			polarity				=> 'invert',
+		},
+	"59"	=>	##  AK-HD-4 remote | 4 Buttons
+						# https://github.com/RFD-FHEM/RFFHEM/issues/133
+						# MU;P0=819;P1=-919;P2=234;P3=-320;P4=8602;P6=156;D=01230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034123030123030123030301212301230123030303030123030341230301230301230303012123012301230303030301230303412303012303012303030121230123012303030303012303034163;CP=0;O;
+						# MU;P0=-334;P2=8581;P3=237;P4=-516;P5=782;P6=-883;D=23456305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505630505630505056363056305630505050505630505026305056305056305050563630563056305050505056305050263050563050563050505636305630563050505050563050502630505;CP=5;O;
 		{
-			name			=> 'AK-HD-4',	
-			id          	=> '59',
-			clockabs     	=> 230, 						
-			zero			=> [-4,1],
-			one				=> [-1,4],
-			start			=> [-1,37],						
-			format 			=> 'twostate',	# tristate can't be migrated from bin into hex!
-			preamble		=> 'u59#',			# Append to converted message	
-			postamble		=> '',		# Append to converted message	 	
-			#clientmodule    => '',
-			modulematch     => '',
-			length_min      => '24',
-			length_max      => '24',
-		},			
-	"60" =>	## ELV, LA CROSSE (WS2000/WS7000)
-					# MU;P0=32001;P1=-381;P2=835;P3=354;P4=-857;D=01212121212121212121343421212134342121213434342121343421212134213421213421212121342121212134212121213421212121343421343430;CP=2;R=53;
-					# tested sensors:   WS-7000-20, AS2000, ASH2000, S2000, S2000I, S2001A, S2001IA,
-					#                   ASH2200, S300IA, S2001I, S2000ID, S2001ID, S2500H 
-					# not tested:       AS3, S2000W, S2000R, WS7000-15, WS7000-16, WS2500-19, S300TH, S555TH
-					# das letzte Bit (1) und mehrere Bit (0) Preambel fehlen meistens
-					#  ___        _
-					# |   |_     | |___
-					#  Bit 0      Bit 1
-					# kurz 366 mikroSek / lang 854 mikroSek / gesamt 1220 mikroSek - Sollzeiten 
+			name						=> 'AK-HD-4',
+			id							=> '59',
+			clockabs				=> 230,
+			zero						=> [-4,1],
+			one							=> [-1,4],
+			start						=> [-1,37],
+			format					=> 'twostate',	# tristate can't be migrated from bin into hex!
+			preamble				=> 'u59#',			# Append to converted message
+			postamble				=> '',					# Append to converted message
+			#clientmodule		=> '',
+			modulematch			=> '',
+			length_min			=> '24',
+			length_max			=> '24',
+		},
+	"60"	=>	## ELV, LA CROSSE (WS2000/WS7000)
+						# MU;P0=32001;P1=-381;P2=835;P3=354;P4=-857;D=01212121212121212121343421212134342121213434342121343421212134213421213421212121342121212134212121213421212121343421343430;CP=2;R=53;
+						# tested sensors:   WS-7000-20, AS2000, ASH2000, S2000, S2000I, S2001A, S2001IA,
+						#                   ASH2200, S300IA, S2001I, S2000ID, S2001ID, S2500H 
+						# not tested:       AS3, S2000W, S2000R, WS7000-15, WS7000-16, WS2500-19, S300TH, S555TH
+						# das letzte Bit (1) und mehrere Bit (0) Preambel fehlen meistens
+						#  ___        _
+						# |   |_     | |___
+						#  Bit 0      Bit 1
+						# kurz 366 mikroSek / lang 854 mikroSek / gesamt 1220 mikroSek - Sollzeiten 
 		{
-			name                 => 'WS2000',
-			comment              => 'Series WS2000/WS7000 of various sensors',
-			id                   => '60',
-			one                  => [3,-7],	
-			zero                 => [7,-3],
-			clockabs             => 122,
-			preamble             => 'K',        # prepend to converted message
-			postamble            => '',         # Append to converted message
-			clientmodule         => 'CUL_WS',   
-			length_min           => '38',       # 46, letztes Bit fehlt = 45, 10 Bit Preambel = 35 Bit Daten
-			length_max           => '82',
-			postDemodulation     => \&SIGNALduino_postDemo_WS2000,
-		}, 
-
+			name								=> 'WS2000',
+			comment							=> 'Series WS2000/WS7000 of various sensors',
+			id									=> '60',
+			one									=> [3,-7],
+			zero								=> [7,-3],
+			clockabs						=> 122,
+			preamble						=> 'K',				# prepend to converted message
+			postamble						=> '',				# Append to converted message
+			clientmodule				=> 'CUL_WS',
+			length_min					=> '38',			# 46, letztes Bit fehlt = 45, 10 Bit Preambel = 35 Bit Daten
+			length_max					=> '82',
+			postDemodulation		=> \&SIGNALduino_postDemo_WS2000,
+		},
 	"61" =>	## ELV FS10
 					# tested transmitter:   FS10-S8, FS10-S4, FS10-ZE
 					# tested receiver:      FS10-ST, FS10-MS, WS3000-TV, PC-Wettersensor-Empfaenger
@@ -1242,35 +1239,35 @@
 			one						=> [1,-2],
 			zero					=> [1,-1],
 			clockabs			=> 400,
-			pause					=> [-81],         # 400*81=32400*6=194400 - pause between repeats of send messages (clockabs*pause must be < 32768)
+			pause					=> [-81],				# 400*81=32400*6=194400 - pause between repeats of send messages (clockabs*pause must be < 32768)
 			format				=> 'twostate',
-			preamble			=> 'P61#',      # prepend to converted message
-			postamble			=> '',         # Append to converted message
+			preamble			=> 'P61#',			# prepend to converted message
+			postamble			=> '',					# Append to converted message
 			clientmodule	=> 'FS10',
 			#modulematch	=> '',
-			length_min		=> '38',	# eigentlich 41 oder 46 (Pruefsumme nicht bei allen)
-			length_max		=> '48',	# eigentlich 46
-		}, 
+			length_min		=> '38',				# eigentlich 41 oder 46 (Pruefsumme nicht bei allen)
+			length_max		=> '48',				# eigentlich 46
+		},
 	"62" => ## Clarus_Switch  
 					# MU;P0=-5893;P4=-634;P5=498;P6=-257;P7=116;D=45656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674565656747474747474565670745674747474745674567456745656567474747474745656707456747474747456745674567456565674747474747456567074567474747474567456745674567;CP=7;O;		
 		{
-			name         => 'Clarus_Switch',
-			id           => '62',
-			one          => [3,-1],
-			zero         => [1,-3],
-			start        => [1,-35], # ca 30-40
-			clockabs     => 189, 
-			preamble     => 'i', # prepend to converted message
-			clientmodule => 'IT', 
-			#modulematch => '', 
-			length_min   => '24',
-			length_max   => '24',		
+			name					=> 'Clarus_Switch',
+			id						=> '62',
+			one						=> [3,-1],
+			zero					=> [1,-3],
+			start					=> [1,-35],		# ca 30-40
+			clockabs			=> 189,
+			preamble			=> 'i',				# prepend to converted message
+			clientmodule	=> 'IT',
+			#modulematch	=> '', 
+			length_min		=> '24',
+			length_max		=> '24',
 		},
 	"63" => ## Warema MU
 					# https://forum.fhem.de/index.php/topic,38831.msg395978/topicseen.html#msg395978 | https://www.mikrocontroller.net/topic/264063
 					# MU;P0=-2988;P1=1762;P2=-1781;P3=-902;P4=871;P5=6762;P6=5012;D=0121342434343434352434313434243521342134343436;
 					# MU;P0=6324;P1=-1789;P2=864;P3=-910;P4=1756;D=0123234143212323232323032321234141032323232323232323;CP=2;
-		{			
+		{
 			name					=> 'Warema',
 			comment				=> 'developId, is still experimental',
 			id						=> '63',
@@ -1278,99 +1275,99 @@
 			one						=> [1],
 			zero					=> [0],
 			clockabs			=> 800, 
-			syncabs				=> '6700',# Special field for filterMC function
-			preamble			=> 'u63', # prepend to converted message
-			#clientmodule => '', 
-			#modulematch => '', 
-			length_min   => '24',
-			#length_max  => '',	   # missing
-			filterfunc   => 'SIGNALduino_filterMC',
+			syncabs				=> '6700',	# Special field for filterMC function
+			preamble			=> 'u63',		# prepend to converted message
+			#clientmodule	=> '', 
+			#modulematch	=> '', 
+			length_min		=> '24',
+			#length_max		=> '',			# missing
+			filterfunc		=> 'SIGNALduino_filterMC',
 		},
-	"64" => ##  WH2 #############################################################################
-			# MU;P0=-32001;P1=457;P2=-1064;P3=1438;D=0123232323212121232123232321212121212121212323212121232321;CP=1;R=63;
-			# MU;P0=-32001;P1=473;P2=-1058;P3=1454;D=0123232323212121232123232121212121212121212121232321212321;CP=1;R=51;
-			# MU;P0=134;P1=-113;P3=412;P4=-1062;P5=1379;D=01010101013434343434343454345454345454545454345454545454343434545434345454345454545454543454543454345454545434545454345;CP=3;
+	"64"	=>	##  WH2 #############################################################################
+						# MU;P0=-32001;P1=457;P2=-1064;P3=1438;D=0123232323212121232123232321212121212121212323212121232321;CP=1;R=63;
+						# MU;P0=-32001;P1=473;P2=-1058;P3=1454;D=0123232323212121232123232121212121212121212121232321212321;CP=1;R=51;
+						# MU;P0=134;P1=-113;P3=412;P4=-1062;P5=1379;D=01010101013434343434343454345454345454545454345454545454343434545434345454345454545454543454543454345454545434545454345;CP=3;
 		{
 			name					=> 'WH2',
 			id						=> '64',
-			one						=> [1,-2],   
-			zero					=> [3,-2], 
+			one						=> [1,-2],
+			zero					=> [3,-2],
 			clockabs			=> 490,
-			clientmodule	=> 'SD_WS',  
+			clientmodule	=> 'SD_WS',
 			modulematch		=> '^W64*',
-			preamble			=> 'W64#',       # prepend to converted message
-			postamble			=> '',           # Append to converted message       
+			preamble			=> 'W64#',				# prepend to converted message
+			postamble			=> '',						# Append to converted message
 			#clientmodule => '',
 			length_min		=> '48',
 			length_max		=> '54',
 		},
-	"65" => ## Homeeasy
-			# MS;P1=231;P2=-1336;P4=-312;P5=-8920;D=15121214141412121212141414121212121414121214121214141212141212141212121414121414141212121214141214121212141412141212;CP=1;SP=5;
+	"65"	=>	## Homeeasy
+						# MS;P1=231;P2=-1336;P4=-312;P5=-8920;D=15121214141412121212141414121212121414121214121214141212141212141212121414121414141212121214141214121212141412141212;CP=1;SP=5;
 		{
-			name         => 'HE_EU',
-			comment      => 'Homeeasy',
-			id           => '65',
-			one          => [1,-5.5],
-			zero         => [1,-1.2],
-			sync         => [1,-38],
-			clockabs     => 230,
-			format       => 'twostate',  # not used now
-			preamble     => 'ih',
-			clientmodule => 'IT',
-			length_min   => '57',
-			length_max   => '72',
-			postDemodulation => \&SIGNALduino_HE_EU,
+			name							=> 'HE_EU',
+			comment						=> 'Homeeasy',
+			id								=> '65',
+			one								=> [1,-5.5],
+			zero							=> [1,-1.2],
+			sync							=> [1,-38],
+			clockabs					=> 230,
+			format						=> 'twostate',	# not used now
+			preamble					=> 'ih',
+			clientmodule			=> 'IT',
+			length_min				=> '57',
+			length_max				=> '72',
+			postDemodulation	=> \&SIGNALduino_HE_EU,
 		},
 	"66" => ## TX2 Protocol (Remote Temp Transmitter & Remote Thermo Model 7035)
 			# MU;P0=13312;P1=-2785;P2=4985;P3=1124;P4=-6442;P5=3181;P6=-31980;D=0121345434545454545434545454543454545434343454543434545434545454545454343434545434343434545621213454345454545454345454545434545454343434545434345454345454545454543434345454343434345456212134543454545454543454545454345454543434345454343454543454545454545;CP=3;R=73;O;
 		{
-			name         => 'WS7035',
-			id           => '66',
-			one          => [10,-52],
-			zero         => [27,-52],
-			start        => [-21,42,-21],
-			clockabs     => 122,
-			format       => 'pwm',  # not used now
-			preamble     => 'TX',
-			clientmodule => 'CUL_TX',
-			modulematch  => '^TX......',
-			length_min   => '43',
-			length_max   => '44',
-			postDemodulation => \&SIGNALduino_postDemo_WS7035,
+			name							=> 'WS7035',
+			id								=> '66',
+			one								=> [10,-52],
+			zero							=> [27,-52],
+			start							=> [-21,42,-21],
+			clockabs					=> 122,
+			format						=> 'pwm',				# not used now
+			preamble					=> 'TX',
+			clientmodule			=> 'CUL_TX',
+			modulematch				=> '^TX......',
+			length_min				=> '43',
+			length_max				=> '44',
+			postDemodulation	=> \&SIGNALduino_postDemo_WS7035,
 		},
-	"67" => ## TX2 Protocol (Remote Datalink & Remote Thermo Model 7053, 7054)
-			# MU;P0=3381;P1=-672;P2=-4628;P3=1142;P4=-30768;D=010 2320232020202020232020232020202320232323202323202020202020202020 4 010 2320232020202020232020232020202320232323202323202020202020202020 0;CP=0;R=45;
-			# MU;P0=1148;P1=3421;P6=-664;P7=-4631;D=161 7071707171717171707171707171717171707070717071717171707071717171 0;CP=1;R=29;
-			# Message repeats 4 x with pause of ca. 30-34 mS
-			#           __               ____
-			#  ________|  |     ________|    |
-			#      Bit 1             Bit 0
-			#    4630  1220       4630   3420   mikroSek - mit Oszi gemessene Zeiten
-			{
-				name             => 'WS7053',	
-				id               => '67',
-				one              => [-38,10],     # -4636, 1220
-				zero             => [-38,28],     # -4636, 3416
-				clockabs         => 122,
-				preamble         => 'TX',         # prepend to converted message
-				clientmodule     => 'CUL_TX',
-				modulematch      => '^TX......',
-				length_min       => '32',
-				length_max       => '34',
-				postDemodulation => \&SIGNALduino_postDemo_WS7053,
-			},
-  "68" => ## PFR-130 ###########################################################################
-		  # MS;P0=-3890;P1=386;P2=-2191;P3=-8184;D=1312121212121012121212121012121212101012101010121012121210121210101210101012;CP=1;SP=3;R=20;O;
-		  # MS;P0=-2189;P1=371;P2=-3901;P3=-8158;D=1310101010101210101010101210101010121210121212101210101012101012121012121210;CP=1;SP=3;R=20;O;
+	"67"	=>	## TX2 Protocol (Remote Datalink & Remote Thermo Model 7053, 7054)
+						# MU;P0=3381;P1=-672;P2=-4628;P3=1142;P4=-30768;D=010 2320232020202020232020232020202320232323202323202020202020202020 4 010 2320232020202020232020232020202320232323202323202020202020202020 0;CP=0;R=45;
+						# MU;P0=1148;P1=3421;P6=-664;P7=-4631;D=161 7071707171717171707171707171717171707070717071717171707071717171 0;CP=1;R=29;
+						# Message repeats 4 x with pause of ca. 30-34 mS
+						#           __               ____
+						#  ________|  |     ________|    |
+						#      Bit 1             Bit 0
+						#    4630  1220       4630   3420   mikroSek - mit Oszi gemessene Zeiten
+		{
+			name							=> 'WS7053',
+			id								=> '67',
+			one								=> [-38,10],     # -4636, 1220
+			zero							=> [-38,28],     # -4636, 3416
+			clockabs					=> 122,
+			preamble					=> 'TX',         # prepend to converted message
+			clientmodule			=> 'CUL_TX',
+			modulematch				=> '^TX......',
+			length_min				=> '32',
+			length_max				=> '34',
+			postDemodulation	=> \&SIGNALduino_postDemo_WS7053,
+		},
+	"68"	=>	## PFR-130 ###########################################################################
+						# MS;P0=-3890;P1=386;P2=-2191;P3=-8184;D=1312121212121012121212121012121212101012101010121012121210121210101210101012;CP=1;SP=3;R=20;O;
+						# MS;P0=-2189;P1=371;P2=-3901;P3=-8158;D=1310101010101210101010101210101010121210121212101210101012101012121012121210;CP=1;SP=3;R=20;O;
 		{
 			name					=> 'PFR-130',
 			id						=> '68',
 			one						=> [1,-10],
 			zero					=> [1,-5],
 			sync					=> [1,-21],	
-			clockabs   		=> 380,
-			preamble			=> 's',			# prepend to converted message	 	
-			postamble			=> '00',		# Append to converted message	 	
+			clockabs			=> 380,
+			preamble			=> 's',				# prepend to converted message
+			postamble			=> '00',			# Append to converted message
 			clientmodule	=> 'CUL_TCM97001',
 			length_min		=> '36',
 			length_max		=> '42',
@@ -1389,19 +1386,19 @@
 					# MU;P0=12376;P1=360;P2=-10284;P3=1016;P4=-507;P6=521;P7=-1012;D=01234343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343434676767346767343404343434343434343467676734346767346734676767676734673434673434346734343;CP=6;R=55;O;
 					# MU;P0=-3656;P1=12248;P2=-519;P3=1008;P4=506;P5=-1033;D=01232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323245453245454532321232323232323232324545453232454532453245454545453245323245323232453232323;CP=4;R=48;O;
 		{
-			name            => 'Hoermann',
-			comment         => 'Remote control HS1-868-BS, HSM4',
-			id              => '69',
-			zero            => [2,-1],     # 1020,510
-			one             => [1,-2],     # 510,1020
-			start           => [25,-1],    # 12750,510
-			clockabs        => 510,
-			format          => 'twostate',
-			clientmodule    => 'SD_UT',
-			modulematch     => '^P69#.{11}',
-			preamble        => 'P69#',
-			length_min      => '44',
-			length_max      => '44',
+			name							=> 'Hoermann',
+			comment						=> 'Remote control HS1-868-BS, HSM4',
+			id								=> '69',
+			zero							=> [2,-1],     # 1020,510
+			one								=> [1,-2],     # 510,1020
+			start							=> [25,-1],    # 12750,510
+			clockabs					=> 510,
+			format						=> 'twostate',
+			clientmodule			=> 'SD_UT',
+			modulematch				=> '^P69#.{11}',
+			preamble					=> 'P69#',
+			length_min				=> '44',
+			length_max				=> '44',
 		},
 	"70" => ## FHT80TF (Funk-Tuer-Fenster-Melder FHT 80TF und FHT 80TF-2)
 					# closed MU;P0=-24396;P1=417;P2=-376;P3=610;P4=-582;D=012121212121212121212121234123434121234341212343434121234123434343412343434121234341212121212341212341234341234123434;CP=1;R=35;
@@ -1429,10 +1426,10 @@
 			clockabs			=> 580,
 			zero					=> [3,-2],
 			one						=> [1,-1.5],
-			format				=> 'twostate',	
-			preamble			=> 'W71#',		# prepend to converted message	
+			format				=> 'twostate',
+			preamble			=> 'W71#',			# prepend to converted message
 			clientmodule	=> 'SD_WS',
-			#modulematch     => '^W71#.*'
+			#modulematch	=> '^W71#.*'
 			length_min		=> '48',
 			length_max		=> '48',
 		},
@@ -1442,43 +1439,43 @@
 			# MU;P0=-760;P1=334;P2=693;P3=-399;P4=-8942;P5=4796;P6=-1540;D=01010102310232310101010102310232323101010102310101010101023102323102323102323102310101010102310232323101010102310101010101023102310231023102456102310232310232310231010101010231023232310101010231010101010102310231023102310245610231023231023231023101010101;CP=1;R=45;O;
 			# MU;P0=-8848;P1=4804;P2=-1512;P3=336;P4=-757;P5=695;P6=-402;D=0123456345656345656345634343434345634565656343434345634343434343456345634563456345;CP=3;R=49;
 		{
-			name					=> 'Siro shutter',
-			id						=> '72',
-			dispatchequals  =>  'true',
-			one						=> [2,-1.2],    # 680, -400
-			zero					=> [1,-2.2],    # 340, -750
-			start					=> [14,-4.4],   # 4800,-1520
-			clockabs			=> 340,
-			format				=> 'twostate',	  		
-			preamble			=> 'P72#',		# prepend to converted message	
-			clientmodule	=> 'Siro',
-			#modulematch 	=> '',  			
-			length_min   	=> '39',
-			length_max   	=> '40',
-			msgOutro			=> 'SR;P0=-8500;D=0;',
+			name						=> 'Siro shutter',
+			id							=> '72',
+			dispatchequals	=>  'true',
+			one							=> [2,-1.2],		# 680, -400
+			zero						=> [1,-2.2],		# 340, -750
+			start						=> [14,-4.4],		# 4800,-1520
+			clockabs				=> 340,
+			format					=> 'twostate',
+			preamble				=> 'P72#',			# prepend to converted message
+			clientmodule		=> 'Siro',
+			#modulematch		=> '',
+			length_min			=> '39',
+			length_max			=> '40',
+			msgOutro				=> 'SR;P0=-8500;D=0;',
 		},
- 	"72.1" => # Siro blinds MS     @Dr. Smag
-			  # MS;P0=4803;P1=-1522;P2=333;P3=-769;P4=699;P5=-393;P6=-9190;D=2601234523454523454523452323232323452345454523232323452323232323234523232345454545;CP=2;SP=6;R=61;
+	"72.1"	=>	# Siro blinds MS     @Dr. Smag
+							# MS;P0=4803;P1=-1522;P2=333;P3=-769;P4=699;P5=-393;P6=-9190;D=2601234523454523454523452323232323452345454523232323452323232323234523232345454545;CP=2;SP=6;R=61;
 		{
-			name					=> 'Siro shutter',
-			comment     	=> 'developModule. Siro is not in github',
-			id						=> '72',
-			developId			=> 'm',
-			dispatchequals  =>  'true',
-			one						=> [2,-1.2],    # 680, -400
-			zero					=> [1,-2.2],    # 340, -750
-			sync					=> [14,-4.4],   # 4800,-1520
-			clockabs			=> 340,
-			format				=> 'twostate',	  		
-			preamble			=> 'P72#',		# prepend to converted message	
-			clientmodule	=> 'Siro',
-			#modulematch 	=> '',  			
-			length_min   	=> '39',
-			length_max   	=> '40',
-			#msgOutro	=> 'SR;P0=-8500;D=0;',
+			name						=> 'Siro shutter',
+			comment					=> 'developModule. Siro is not in github',
+			id							=> '72',
+			developId				=> 'm',
+			dispatchequals	=>  'true',
+			one							=> [2,-1.2],		# 680, -400
+			zero						=> [1,-2.2],		# 340, -750
+			sync						=> [14,-4.4],		# 4800,-1520
+			clockabs				=> 340,
+			format					=> 'twostate',
+			preamble				=> 'P72#',			# prepend to converted message
+			clientmodule		=> 'Siro',
+			#modulematch		=> '',
+			length_min			=> '39',
+			length_max			=> '40',
+			#msgOutro				=> 'SR;P0=-8500;D=0;',
 		},
-	"73" => ## FHT80 - Raumthermostat (868Mhz),  @HomeAutoUser
-			# MU;P0=136;P1=-112;P2=631;P3=-392;P4=402;P5=-592;P6=-8952;D=0123434343434343434343434325434343254325252543432543434343434325434343434343434343254325252543254325434343434343434343434343252525432543464343434343434343434343432543434325432525254343254343434343432543434343434343434325432525254325432543434343434343434;CP=4;R=250;
+	"73"	=>	## FHT80 - Raumthermostat (868Mhz),  @HomeAutoUser
+						# MU;P0=136;P1=-112;P2=631;P3=-392;P4=402;P5=-592;P6=-8952;D=0123434343434343434343434325434343254325252543432543434343434325434343434343434343254325252543254325434343434343434343434343252525432543464343434343434343434343432543434325432525254343254343434343432543434343434343434325432525254325432543434343434343434;CP=4;R=250;
 		{
 			name							=> 'FHT80',
 			comment						=> 'Roomthermostat (868Mhz only receive)',
@@ -1495,82 +1492,82 @@
 			length_max				=> '67',
 			postDemodulation	=> \&SIGNALduino_postDemo_FHT80,
 		},
-	"74" => ## FS20 - 'Remote Control (868Mhz),  @HomeAutoUser
-			# MU;P0=-10420;P1=-92;P2=398;P3=-417;P5=596;P6=-592;D=1232323232323232323232323562323235656232323232356232356232623232323232323232323232323235623232323562356565623565623562023232323232323232323232356232323565623232323235623235623232323232323232323232323232323562323232356235656562356562356202323232323232323;CP=2;R=72;
+	"74"	=>	## FS20 - 'Remote Control (868Mhz),  @HomeAutoUser
+						# MU;P0=-10420;P1=-92;P2=398;P3=-417;P5=596;P6=-592;D=1232323232323232323232323562323235656232323232356232356232623232323232323232323232323235623232323562356565623565623562023232323232323232323232356232323565623232323235623235623232323232323232323232323232323562323232356235656562356562356202323232323232323;CP=2;R=72;
 		{
 			name							=> 'FS20',
 			comment						=> 'Remote Control (868Mhz)',
 			id								=> '74',
-			one								=> [1.5,-1.5], # 600
-			zero							=> [1,-1], # 400
+			one								=> [1.5,-1.5],	# 600
+			zero							=> [1,-1],			# 400
 			pause							=> [-25],
 			clockabs					=> 400,
-			format						=> 'twostate', # not used now
+			format						=> 'twostate',	# not used now
 			clientmodule			=> 'FS20',
 			preamble					=> '810b04f70101a001',
 			length_min				=> '50',
 			length_max				=> '67',
 			postDemodulation	=> \&SIGNALduino_postDemo_FS20,
 		},
-	"75" => ## ConradRSL2 @litronics https://github.com/RFD-FHEM/SIGNALDuino/issues/69
-            # ! same definition how ID 5, but other length !
-            # !! protocol needed revision - start or sync failed !! https://github.com/RFD-FHEM/SIGNALDuino/issues/69#issuecomment-440349328
-			# MU;P0=-1365;P1=477;P2=1145;P3=-734;P4=-6332;D=01023202310102323102423102323102323101023232323101010232323231023102323102310102323102423102323102323101023232323101010232323231023102323102310102323102;CP=1;R=12;
+	"75"	=>	## ConradRSL2 @litronics https://github.com/RFD-FHEM/SIGNALDuino/issues/69
+						# ! same definition how ID 5, but other length !
+						# !! protocol needed revision - start or sync failed !! https://github.com/RFD-FHEM/SIGNALDuino/issues/69#issuecomment-440349328
+						# MU;P0=-1365;P1=477;P2=1145;P3=-734;P4=-6332;D=01023202310102323102423102323102323101023232323101010232323231023102323102310102323102423102323102323101023232323101010232323231023102323102310102323102;CP=1;R=12;
 		{
-			name					=> 'ConradRSL2', 
+			name					=> 'ConradRSL2',
 			id						=> '75',
 			one						=> [3,-1],
 			zero					=> [1,-3],
 			clockabs			=> 500, 
-			format				=> 'twostate', 
+			format				=> 'twostate',
 			developId			=> 'y',
 			clientmodule	=> 'SD_RSL',
 			preamble			=> 'P1#',  
-			modulematch		=> '^P1#[A-Fa-f0-9]{8}', 
+			modulematch		=> '^P1#[A-Fa-f0-9]{8}',
 			length_min		=> '32',
 			length_max 		=> '40',
 		},
-	"76" => ##  Kabellose LED-Weihnachtskerzen XM21-0
+	"76"	=>	##  Kabellose LED-Weihnachtskerzen XM21-0
 		{
 			name					=> 'xm21',
 			comment				=> 'reserviert, LED Lichtrekette on',
 			id						=> '76',
 			developId			=> 'p',
-			one						=> [1.2,-2], # 120,-200
-			zero					=> [],   # existiert nicht
-			start					=> [4.5,-2], # 450,-200 Starsequenz
+			one						=> [1.2,-2],			# 120,-200
+			zero					=> [],						# existiert nicht
+			start					=> [4.5,-2],			# 450,-200 Starsequenz
 			clockabs			=> 100,
-			format				=> 'twostate', # not used now
+			format				=> 'twostate',		# not used now
 			clientmodule	=> '',
 			preamble			=> 'P76',
 			length_min		=> 64,
 			length_max		=> 64,
 		},
-	"76.1" => ##  Kabellose LED-Weihnachtskerzen XM21-0
+	"76.1"	=>	##  Kabellose LED-Weihnachtskerzen XM21-0
 		{
 			name					=> 'xm21',
 			comment				=> 'reserviert, LED Lichtrekette off',
 			id						=> '76.1',
 			developId			=> 'p', 
-			one						=> [1.2,-2], # 120,-200
-			zero					=> [],   # existiert nicht
-			start					=> [4.5,-2], # 450,-200 Starsequenz
+			one						=> [1.2,-2],			# 120,-200
+			zero					=> [],						# existiert nicht
+			start					=> [4.5,-2],			# 450,-200 Starsequenz
 			clockabs			=> 100,
-			format				=> 'twostate', # not used now
+			format				=> 'twostate',		# not used now
 			clientmodule	=> '',
 			preamble			=> 'P76',
 			length_min		=> 58,
 			length_max		=> 58,
 		},
-	"77" => ## https://github.com/juergs/NANO_DS1820_4Fach
-            # MU;P0=102;P1=236;P2=-2192;P3=971;P6=-21542;D=01230303030103010303030303010103010303010303010101030301030103030303010101030301030303010163030303010301030303030301010301030301030301010103030103010303030301010103030103030301016303030301030103030303030101030103030103030101010303010301030303030101010303;CP=0;O;
-            # MU;P0=-1483;P1=239;P2=970;P3=-21544;D=01020202010132020202010201020202020201010201020201020201010102020102010202020201010102020102020201013202020201020102020202020101020102020102020101010202010201020202020101010202010202020101;CP=1;
-            # MU;P0=-168;P1=420;P2=-416;P3=968;P4=-1491;P5=242;P6=-21536;D=01234343434543454343434343454543454345434543454345434343434343434343454345434343434345454363434343454345434343434345454345434543454345434543434343434343434345434543434343434545436343434345434543434343434545434543454345434543454343434343434343434543454343;CP=3;O;
-            # MU;P0=-1483;P1=969;P2=236;P3=-21542;D=01010102020131010101020102010101010102020102010201020102010201010101010101010102010201010101010202013101010102010201010101010202010201020102010201020101010101010101010201020101010101020201;CP=1;
-            # MU;P0=-32001;P1=112;P2=-8408;P3=968;P4=-1490;P5=239;P6=-21542;D=01234343434543454343434343454543454345454343454345434343434343434343454345434343434345454563434343454345434343434345454345434545434345434543434343434343434345434543434343434545456343434345434543434343434545434543454543434543454343434343434343434543454343;CP=3;O;
-            # MU;P0=-1483;P1=968;P2=240;P3=-21542;D=01010102020231010101020102010101010102020102010202010102010201010101010101010102010201010101010202023101010102010201010101010202010201020201010201020101010101010101010201020101010101020202;CP=1;
-            # MU;P0=-32001;P1=969;P2=-1483;P3=237;P4=-21542;D=01212121232123212121212123232123232121232123212321212121212121212123212321212121232123214121212123212321212121212323212323212123212321232121212121212121212321232121212123212321412121212321232121212121232321232321212321232123212121212121212121232123212121;CP=1;O;
-            # MU;P0=-1485;P1=967;P2=236;P3=-21536;D=010201020131010101020102010101010102020102020101020102010201010101010101010102010201010101020102013101010102010201010101010202010202010102010201020101010101010101010201020101010102010201;CP=1;
+	"77"	=>	## https://github.com/juergs/NANO_DS1820_4Fach
+						# MU;P0=102;P1=236;P2=-2192;P3=971;P6=-21542;D=01230303030103010303030303010103010303010303010101030301030103030303010101030301030303010163030303010301030303030301010301030301030301010103030103010303030301010103030103030301016303030301030103030303030101030103030103030101010303010301030303030101010303;CP=0;O;
+						# MU;P0=-1483;P1=239;P2=970;P3=-21544;D=01020202010132020202010201020202020201010201020201020201010102020102010202020201010102020102020201013202020201020102020202020101020102020102020101010202010201020202020101010202010202020101;CP=1;
+						# MU;P0=-168;P1=420;P2=-416;P3=968;P4=-1491;P5=242;P6=-21536;D=01234343434543454343434343454543454345434543454345434343434343434343454345434343434345454363434343454345434343434345454345434543454345434543434343434343434345434543434343434545436343434345434543434343434545434543454345434543454343434343434343434543454343;CP=3;O;
+						# MU;P0=-1483;P1=969;P2=236;P3=-21542;D=01010102020131010101020102010101010102020102010201020102010201010101010101010102010201010101010202013101010102010201010101010202010201020102010201020101010101010101010201020101010101020201;CP=1;
+						# MU;P0=-32001;P1=112;P2=-8408;P3=968;P4=-1490;P5=239;P6=-21542;D=01234343434543454343434343454543454345454343454345434343434343434343454345434343434345454563434343454345434343434345454345434545434345434543434343434343434345434543434343434545456343434345434543434343434545434543454543434543454343434343434343434543454343;CP=3;O;
+						# MU;P0=-1483;P1=968;P2=240;P3=-21542;D=01010102020231010101020102010101010102020102010202010102010201010101010101010102010201010101010202023101010102010201010101010202010201020201010201020101010101010101010201020101010101020202;CP=1;
+						# MU;P0=-32001;P1=969;P2=-1483;P3=237;P4=-21542;D=01212121232123212121212123232123232121232123212321212121212121212123212321212121232123214121212123212321212121212323212323212123212321232121212121212121212321232121212123212321412121212321232121212121232321232321212321232123212121212121212121232123212121;CP=1;O;
+						# MU;P0=-1485;P1=967;P2=236;P3=-21536;D=010201020131010101020102010101010102020102020101020102010201010101010101010102010201010101020102013101010102010201010101010202010202010102010201020101010101010101010201020101010102010201;CP=1;
 		{
 			name					=> 'NANO_DS1820_4Fach',
 			comment				=> 'Selbstbau Sensor',
@@ -1578,29 +1575,29 @@
 			developId			=> 'y', 
 			zero					=> [4,-6],
 			one						=> [1,-6],
-			clockabs     	=> 250,
-			format				=> 'pwm',	    # 
-			preamble			=> 'TX',		# prepend to converted message	
+			clockabs			=> 250,
+			format				=> 'pwm',				#
+			preamble			=> 'TX',				# prepend to converted message
 			clientmodule	=> 'CUL_TX',
 			modulematch		=> '^TX......',
 			length_min		=> '43',
 			length_max		=> '44',
-			remove_zero		=> 1,           # Removes leading zeros from output
+			remove_zero		=> 1,						# Removes leading zeros from output
 		},
 	"78" => # MU;P0=313;P1=1212;P2=-309;P4=-2024;P5=-16091;P6=2014;D=01204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040562620404626204040404040462046204040;CP=0;R=236;)
-			# https://forum.fhem.de/index.php/topic,39153.0.html		
+			# https://forum.fhem.de/index.php/topic,39153.0.html
 		{
 			name					=> 'geiger',
 			comment				=> 'geiger blind motors',
 			id						=> '78',
 			developId			=> 'y', 
-			zero					=> [1,-6.6], 		
-			one						=> [6.6,-1],   		 
-			start					=> [-53],		
-			clockabs     	=> 300,					 
-			format				=> 'twostate',	     
-			preamble			=> 'u78#',			# prepend to converted message	
-			clientmodule	=> 'SIGNALduino_un',   	
+			zero					=> [1,-6.6],
+			one						=> [6.6,-1],
+			start					=> [-53],
+			clockabs     	=> 300,
+			format				=> 'twostate',
+			preamble			=> 'u78#',			# prepend to converted message
+			clientmodule	=> 'SIGNALduino_un',
 			#modulematch	=> '^TX......', 
 			length_min		=> '14',
 			length_max		=> '18',
@@ -1609,26 +1606,26 @@
 	"79" => ## m-e Funkmodul VTX-BELL
 			# https://github.com/RFD-FHEM/SIGNALDuino/issues/84
 			# MU;P0=656;P1=-656;P2=335;P3=-326;P4=-5024;D=0123012123012303030301 24 230123012123012303030301 24 230123012123012303030301 24 2301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303012423012301212301230303030124230123012123012303030301242301230121230123030303;CP=2;O;
-			# https://forum.fhem.de/index.php/topic,64251.0.html			
+			# https://forum.fhem.de/index.php/topic,64251.0.html
 			# MU;P0=540;P1=-421;P2=-703;P3=268;P4=-4948;D=4 323102323101010101010232 34 323102323101010101010232 34 323102323101010101010232 34 3231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010102323432310232310101010101023234323102323101010101010232343231023231010101010;CP=3;O;
 			# https://github.com/RFD-FHEM/RFFHEM/issues/252
 			# MU;P0=-24096;P1=314;P2=-303;P3=615;P4=-603;P5=220;P6=-4672;D=0123456123412341414141412323234 16 123412341414141412323234 16 12341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414141412323234161234123414141414123232341612341234141414141232323416123412341414;CP=1;R=26;O;
 			# MU;P0=-10692;P1=602;P2=-608;P3=311;P4=-305;P5=-4666;D=01234123232323234141412 35 341234123232323234141412 35 341234123232323234141412 35 34123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414141235341234123232323234141412353412341232323232341414123534123412323232323414;CP=3;R=47;O;
 			# MU;P0=-7152;P1=872;P2=-593;P3=323;P4=-296;P5=622;P6=-4650;D=01234523232323234545452 36 345234523232323234545452 36 345234523232323234545452 36 34523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454545236345234523232323234545452363452345232323232345454523634523452323232323454;CP=3;R=26;O;
 		{
-			name          => 'm-e VTX-BELL',
-			comment       => 'wireless chime VTX-BELL',
-			id            => '79',
-			zero          => [-2,1],
-			one           => [-1,2],
-			start         => [-15,1],
-			clockabs      => 330,
-			format        => 'twostate',	    # 
-			preamble      => 'P79#',	# prepend to converted message	
-			clientmodule  => 'SD_BELL',
-			modulematch   => '^P79#.*',
-			length_min    => '12',
-			length_max    => '12',
+			name					=> 'm-e VTX-BELL',
+			comment				=> 'wireless chime VTX-BELL',
+			id						=> '79',
+			zero					=> [-2,1],
+			one						=> [-1,2],
+			start					=> [-15,1],
+			clockabs			=> 330,
+			format				=> 'twostate',	# 
+			preamble			=> 'P79#',			# prepend to converted message
+			clientmodule	=> 'SD_BELL',
+			modulematch		=> '^P79#.*',
+			length_min		=> '12',
+			length_max		=> '12',
 		},
 	"80" => ## EM (Energy-Monitor) Funkprotokoll (868Mhz),  @HomeAutoUser | Derwelcherichbin
 			# MU;P1=-417;P2=385;P3=-815;P4=-12058;D=42121212121212121212121212121212121232321212121212121232321212121212121232323212323212321232121212321212123232121212321212121232323212121212121232121212121212121232323212121212123232321232121212121232123232323212321;CP=2;R=87;
@@ -1646,21 +1643,21 @@
 			length_max				=> '114',
 			postDemodulation	=> \&SIGNALduino_postDemo_EM,
 		},
-	"81" => ## Remote control SA-434-1 based on HT12E @ elektron-bbs
-			# MU;P0=-485;P1=188;P2=-6784;P3=508;P5=1010;P6=-974;P7=-17172;D=0123050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056;CP=3;R=0;																																																																																				   
-			# MU;P0=-1756;P1=112;P2=-11752;P3=496;P4=-495;P5=998;P6=-988;P7=-17183;D=0123454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456;CP=3;R=0;
-			#      __        ____
-			# ____|  |    __|    |
-			#  Bit 1       Bit 0
-			# short 500 microSec / long 1000 microSec / bittime 1500 mikroSek / pilot 12 * bittime, from that 1/3 bitlength high
+	"81"	=>	## Remote control SA-434-1 based on HT12E @ elektron-bbs
+						# MU;P0=-485;P1=188;P2=-6784;P3=508;P5=1010;P6=-974;P7=-17172;D=0123050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056305630563730505056305050563056305637305050563050505630563056373050505630505056;CP=3;R=0;																																																																																				   
+						# MU;P0=-1756;P1=112;P2=-11752;P3=496;P4=-495;P5=998;P6=-988;P7=-17183;D=0123454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456345634563734545456345454563456345637345454563454545634563456373454545634545456;CP=3;R=0;
+						#      __        ____
+						# ____|  |    __|    |
+						#  Bit 1       Bit 0
+						# short 500 microSec / long 1000 microSec / bittime 1500 mikroSek / pilot 12 * bittime, from that 1/3 bitlength high
 		{
 			name					=> 'SA-434-1',
 			comment				=> 'Remote control SA-434-1 mini 923301 based on HT12E (developModule SD_UT is only in github available)',
 			id						=> '81',
 			one						=> [-2,1],			# i.O.
 			zero					=> [-1,2],			# i.O.
-			start					=> [-35,1],		# Message is not provided as MS, worakround is start
-			clockabs			=> 500,                 
+			start					=> [-35,1],			# Message is not provided as MS, worakround is start
+			clockabs			=> 500,
 			format				=> 'twostate',
 			preamble			=> 'P81#',			# prepend to converted message
 			modulematch		=> '^P81#.{3}',
@@ -1668,166 +1665,166 @@
 			length_min		=> '12',
 			length_max		=> '12',
 		},
-	"82" => ## Fernotron shutters and light switches   
-			# https://github.com/RFD-FHEM/RFFHEM/issues/257
-			# MU;P0=-32001;P1=435;P2=-379;P4=-3201;P5=831;P6=-778;D=01212121212121214525252525252521652161452525252525252161652141652521652521652521614165252165252165216521416521616165216525216141652161616521652165214165252161616521652161416525216161652161652141616525252165252521614161652525216525216521452165252525252525;CP=1;O;
-			# the messages received are usual missing 12 bits at the end for some reason. So the checksum byte is missing.
-			# Fernotron protocol is unidirectional. Here we can only receive messages from controllers send to receivers. 
+	"82"	=>	## Fernotron shutters and light switches   
+						# https://github.com/RFD-FHEM/RFFHEM/issues/257
+						# MU;P0=-32001;P1=435;P2=-379;P4=-3201;P5=831;P6=-778;D=01212121212121214525252525252521652161452525252525252161652141652521652521652521614165252165252165216521416521616165216525216141652161616521652165214165252161616521652161416525216161652161652141616525252165252521614161652525216525216521452165252525252525;CP=1;O;
+						# the messages received are usual missing 12 bits at the end for some reason. So the checksum byte is missing.
+						# Fernotron protocol is unidirectional. Here we can only receive messages from controllers send to receivers. 
 		{
-			name           => 'Fernotron',
-			id             => '82',       # protocol number
-			developId      => 'm',
-			dispatchBin    => 'y',
-			one            => [1,-2],     # on=400us, off=800us
-			zero           => [2,-1],     # on=800us, off=400us
-			float          => [1,-8],     # on=400us, off=3200us. the preamble and each 10bit word has one [1,-8] in front
-			pause          => [1,-1],     # preamble (5x)
-			clockabs       => 400,        # 400us
-			preamble       => 'P82#',     # prepend our protocol number to converted message
-			clientmodule   => 'Fernotron',
-			length_min     => '100',      # actual 120 bit (12 x 10bit words to decode 6 bytes data), but last 20 are for checksum
-			length_max     => '3360',     # 3360 bit (336 x 10bit words to decode 168 bytes data) for full timer message
-	    },
-	"83" => ## Remote control RH787T based on MOSDESIGN SEMICONDUCTOR CORP (CMOS ASIC encoder) M1EN compatible HT12E
-			# for example Westinghouse Deckenventilator Delancey, 6 speed buttons, @zwiebelxxl
-			# https://github.com/RFD-FHEM/RFFHEM/issues/250
-			# Taste 1 MU;P0=388;P1=-112;P2=267;P3=-378;P5=585;P6=-693;P7=-11234;D=0123035353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262;CP=2;R=43;O;
-			# Taste 2 MU;P0=-176;P1=262;P2=-11240;P3=112;P5=-367;P6=591;P7=-695;D=0123215656565656717171567156712156565656567171715671567121565656565671717156715671215656565656717171567156712156565656567171715671567121565656565671717156715671215656565656717171567156712156565656567171715671567121565656565671717171717171215656565656717;CP=1;R=19;O;
-			# Taste 3 MU;P0=564;P1=-392;P2=-713;P3=245;P4=-11247;D=0101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023;CP=3;R=40;O;
+			name					=> 'Fernotron',
+			id						=> '82',				# protocol number
+			developId			=> 'm',
+			dispatchBin		=> 'y',
+			one						=> [1,-2],			# on=400us, off=800us
+			zero					=> [2,-1],			# on=800us, off=400us
+			float					=> [1,-8],			# on=400us, off=3200us. the preamble and each 10bit word has one [1,-8] in front
+			pause					=> [1,-1],			# preamble (5x)
+			clockabs			=> 400,					# 400us
+			preamble			=> 'P82#',			# prepend our protocol number to converted message
+			clientmodule	=> 'Fernotron',
+			length_min		=> '100',				# actual 120 bit (12 x 10bit words to decode 6 bytes data), but last 20 are for checksum
+			length_max		=> '3360',			# 3360 bit (336 x 10bit words to decode 168 bytes data) for full timer message
+		},
+	"83"	=>	## Remote control RH787T based on MOSDESIGN SEMICONDUCTOR CORP (CMOS ASIC encoder) M1EN compatible HT12E
+						# for example Westinghouse Deckenventilator Delancey, 6 speed buttons, @zwiebelxxl
+						# https://github.com/RFD-FHEM/RFFHEM/issues/250
+						# Taste 1 MU;P0=388;P1=-112;P2=267;P3=-378;P5=585;P6=-693;P7=-11234;D=0123035353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262623562626272353535353562626235626262723535353535626262356262627235353535356262;CP=2;R=43;O;
+						# Taste 2 MU;P0=-176;P1=262;P2=-11240;P3=112;P5=-367;P6=591;P7=-695;D=0123215656565656717171567156712156565656567171715671567121565656565671717156715671215656565656717171567156712156565656567171715671567121565656565671717156715671215656565656717171567156712156565656567171715671567121565656565671717171717171215656565656717;CP=1;R=19;O;
+						# Taste 3 MU;P0=564;P1=-392;P2=-713;P3=245;P4=-11247;D=0101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023232323431010101010232310232323234310101010102323102323232343101010101023231023;CP=3;R=40;O;
 		{
-			name					=> 'RH787T',	
+			name					=> 'RH787T',
 			comment				=> 'Remote control for example Westinghouse Delancey 7800140 (developModule SD_UT is only in github available)',
-			id          	=> '83',
+			id						=> '83',
 			one						=> [-2,1],
 			zero					=> [-1,2],
 			start					=> [-35,1],				# calculated 12126,31579 µS
-			clockabs			=> 335,                 # calculated ca 336,8421053 µS short - 673,6842105µS long 
-			format				=> 'twostate',	  		# there is a pause puls between words
-			preamble			=> 'P83#',				# prepend to converted message	
+			clockabs			=> 335,						# calculated ca 336,8421053 µS short - 673,6842105µS long 
+			format				=> 'twostate',		# there is a pause puls between words
+			preamble			=> 'P83#',				# prepend to converted message
 			clientmodule	=> 'SD_UT', 
 			modulematch		=> '^P83#.{3}',
 			length_min		=> '12',
 			length_max		=> '12',
 		},
-	"84" => ## Funk Wetterstation Auriol IAN 283582 Version 06/2017 (Lidl), Modell-Nr.: HG02832D, 09/2018@roobbb
-			# https://github.com/RFD-FHEM/RFFHEM/issues/263
-			# MU;P0=-28796;P1=376;P2=-875;P3=834;P4=220;P5=-632;P6=592;P7=-268;D=0123232324545454545456767454567674567456745674545454545456767676767674567674567676767456;CP=4;R=22;
-			# MU;P0=-28784;P1=340;P2=-903;P3=814;P4=223;P5=-632;P6=604;P7=-248;D=0123232324545454545456767456745456767674545674567454545456745454545456767454545456745676;CP=4;R=22;
-			# MU;P0=-21520;P1=235;P2=-855;P3=846;P4=620;P5=-236;P7=-614;D=012323232454545454545451717451717171745171717171717171717174517171745174517174517174545;CP=1;R=217;
-			## Sempre 92596/65395, Hofer/Aldi, WS97210-1, WS97230-1, WS97210-2, WS97230-2
-			# https://github.com/RFD-FHEM/RFFHEM/issues/223
-			# MU;P0=11916;P1=-852;P2=856;P3=610;P4=-240;P5=237;P6=-610;D=01212134563456563434565634565634343456565634565656565634345634565656563434563456343430;CP=5;R=254;
-			# MU;P0=-30004;P1=815;P2=-910;P3=599;P4=-263;P5=234;P6=-621;D=0121212345634565634345656345656343456345656345656565656343456345634563456343434565656;CP=5;R=5;
-	{
-		name         => 'IAN283582',
-		comment      => 'Weatherstation Auriol IAN 283582 / Sempre 92596/65395',
-		id           => '84',
-		one          => [3,-1],
-		zero         => [1,-3],
-		start        => [4,-4,4,-4,4,-4],
-		clockabs     => 215, 
-		format       => 'twostate',
-		preamble     => 'W84#',             # prepend to converted message	
-		postamble    => '',                 # append to converted message	 	
-		clientmodule => 'SD_WS',
-		length_min   => '39',               # das letzte Bit fehlt meistens
-		length_max   => '40',
-	},
-	"85" => ## Funk Wetterstation TFA 35.1140.01 mit Temperatur-/Feuchte- und Windsensor TFA 30.3222.02 09/2018@Iron-R
-			# https://github.com/RFD-FHEM/RFFHEM/issues/266
-			# MU;P0=-509;P1=474;P2=-260;P3=228;P4=718;P5=-745;D=01212303030303012301230123012301230301212121230454545453030303012123030301230303012301212123030301212303030303030303012303012303012303012301212303030303012301230123012301230301212121212454545453030303012123030301230303012301212123030301212303030303030303;CP=3;R=46;O;
-			# MU;P0=-504;P1=481;P2=-254;P3=227;P4=723;P5=-739;P6=-1848;D=01230121212303030121230303030303030453030303012123030301230303012301212303030303030304530303030121230303012303030123012121230303012123030303030303030123030123030123030123012123030303030123012301230123012303012121212364545454530303030121230303012303030123;CP=3;R=45;O;
-			# MU;P0=7944;P1=-724;P2=742;P3=241;P4=-495;P5=483;P6=-248;D=01212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634345656345634343456563421212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634;CP=3;R=47;O;�
-	{
-		name         => 'TFA 30.3222.02',
-		comment      => 'Combisensor for Weatherstation TFA 35.1140.01',
-		id           => '85',
-		one          => [2,-1],
-		zero         => [1,-2],
-		start        => [3,-3,3,-3,3,-3],
-		clockabs     => 250, 
-		format       => 'twostate',
-		preamble     => 'W85#',             # prepend to converted message	
-		postamble    => '',                 # append to converted message	 	
-		clientmodule => 'SD_WS',
-		length_min   => '64',
-		length_max   => '68',
-	},
-	"86" => ## for remote controls:  Novy 840029, CAME TOP 432EV, Neff Transmitter SF01 01319004
-			### CAME TOP 432EV 433,92 MHz für z.B. Drehtor Antrieb:
-			# https://forum.fhem.de/index.php/topic,63370.msg849400.html#msg849400
-			# https://github.com/RFD-FHEM/RFFHEM/issues/151
-			# MU;P0=711;P1=-15288;P4=132;P5=-712;P6=316;P7=-313;D=4565656705656567056567056 16 565656705656567056567056 16 56565670565656705656705616565656705656567056567056165656567056565670565670561656565670565656705656705616565656705656567056567056165656567056565670565670561656565670565656705656705616565656705656567056;CP=6;R=52;
-			# MU;P0=-322;P1=136;P2=-15241;P3=288;P4=-735;P6=723;D=012343434306434343064343430623434343064343430643434306 2343434306434343064343430 623434343064343430643434306234343430643434306434343062343434306434343064343430623434343064343430643434306234343430643434306434343062343434306434343064343430;CP=3;R=27;
-			# MU;P0=-15281;P1=293;P2=-745;P3=-319;P4=703;P5=212;P6=152;P7=-428;D=0 1212121342121213421213421 01 212121342121213421213421 01 21212134212121342121342101212121342121213421213421012121213421212134212134210121243134212121342121342101252526742121213425213421012121213421212134212134210121212134212;CP=1;R=23;
-			# rechteTaste: 0x112 (000100010010), linkeTaste: 0x111 (000100010001), the least significant bits distinguish the keys
-			### remote control Novy 840029 for Novy Pureline 6830 kitchen hood:
-			# https://github.com/RFD-FHEM/RFFHEM/issues/331
-			# light on/off button  # MU;P0=710;P1=353;P2=-403;P4=-761;P6=-16071;D=20204161204120412041204120414141204120202041612041204120412041204141412041202020416120412041204120412041414120412020204161204120412041204120414141204120202041;CP=1;R=40;
-			# plus button          # MU;P0=22808;P1=-24232;P2=701;P3=-765;P4=357;P5=-15970;P7=-406;D=012345472347234723472347234723454723472347234723472347234547234723472347234723472345472347234723472347234723454723472347234723472347234;CP=4;R=39;
-			# minus button         # MU;P0=-8032;P1=364;P2=-398;P3=700;P4=-760;P5=-15980;D=0123412341234123412341412351234123412341234123414123512341234123412341234141235123412341234123412341412351234123412341234123414123;CP=1;R=40;
-			# power button         # MU;P0=-756;P1=718;P2=354;P3=-395;P4=-16056;D=01020202310231310202 42 310231023102310231020202310231310202 42 31023102310231023102020231023131020242310231023102310231020202310231310202;CP=2;R=41;
-			# novy button          # MU;P0=706;P1=-763;P2=370;P3=-405;P4=-15980;D=0123012301230304230123012301230123012303042;CP=2;R=42;
-			### Neff Transmitter SF01 01319004 433,92 MHz for kitchen hood:
-			# https://github.com/RFD-FHEM/RFFHEM/issues/376
-			# MU;P0=706;P1=-160;P2=140;P3=-335;P4=-664;P5=385;P6=-15226;P7=248;D=01210103045303045453030304545453030454530653030453030454530303045454530304747306530304530304545303030454545303045453065303045303045453030304545453030454530653030453030454530303045454530304545306530304530304545303030454545303045453065303045303045453030304;CP=5;O;
-			# MU;P0=-15222;P1=379;P2=-329;P3=712;P6=-661;D=30123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616;CP=1;O;
-			# MU;P0=705;P1=-140;P2=-336;P3=-667;P4=377;P5=-15230;P6=248;D=01020342020343420202034343420202020345420203420203434202020343434202020203654202034202034342020203434342020202034542020342020343420202034343420202020345420203420203434202020343434202020203454202034202034342020203434342020202034542020342020343420202034343;CP=4;O;
-			# MU;P0=704;P1=-338;P2=-670;P3=378;P4=-15227;P5=244;D=01023231010102323231010102310431010231010232310101023232310101025104310102310102323101010232323101010231043101023101023231010102323231010102310431010231010232310101023232310101023104310102310102323101010232323101010231043101023101023231010102323231010102;CP=3;O;
-			# MU;P0=-334;P1=709;P2=-152;P3=-663;P4=379;P5=-15226;P6=250;D=01210134010134340101013434340101340134540101340101343401010134343401013601365401013401013434010101343434010134013454010134010134340101013434340101340134540101340101343401010134343401013401345401013401013434010101343434010134013454010134010134340101013434;CP=4;O;
-	{
-		name					=> 'CAME|Novy|Neff',
-		comment	      => 'CAME TOP 432EV, Novy 840029, Neff SF01 01319004',
-		id            => '86',
-		one						=> [-2,1],
-		zero					=> [-1,2],
-		start         => [-44,1],
-		clockabs      => 350,
-		format        => 'twostate',
-		preamble      => 'P86#',	  # prepend to converted message	
-		clientmodule  => 'SD_UT',
-		#modulematch   => '^P86#.*',
-		length_min    => '12',
-		length_max    => '18',
-	},
-	"87" => ## JAROLIFT Funkwandsender TDRC 16W / TDRCT 04W
-					# https://github.com/RFD-FHEM/RFFHEM/issues/380
-					# MS;P1=1524;P2=-413;P3=388;P4=-3970;P5=-815;P6=778;P7=-16024;D=34353535623562626262626235626262353562623535623562626235356235626262623562626262626262626262626262623535626235623535353535626262356262626262626267123232323232323232323232;CP=3;SP=4;R=226;O;m2;
-					# MS;P0=-15967;P1=1530;P2=-450;P3=368;P4=-3977;P5=-835;P6=754;D=34353562623535623562623562356262626235353562623562623562626235353562623562626262626262626262626262623535626235623535353535626262356262626262626260123232323232323232323232;CP=3;SP=4;R=229;O;
-	{
-		name				=> 'JAROLIFT',
-		comment			=> 'JAROLIFT TDRC_16W / TDRCT_04W',
-		id					=> '87',
-		one					=> [1,-2],
-		zero				=> [2,-1],
-		sync				=> [1,-10],				# this is a end marker, but we use this as a start marker
-		clockabs		=> 400,           # ca 400us
-		developId		=> 'y',
-		format 			=> 'twostate',	  		
-		preamble		=> 'u87#',				# prepend to converted message	
-		#clientmodule    => '',
-		#modulematch     => '',
-		length_min      => '72',			# 72
-		length_max      => '85',			# 85
-	},
-	"88" =>	## Roto Dachfensterrolladen | Aurel Fernbedienung "TX-nM-HCS" (HCS301 Chip) | three buttons -> up, Stop, down
-					# https://forum.fhem.de/index.php/topic,91244.0.html
-					# MS;P1=361;P2=-435;P4=-4018;P5=-829;P6=759;P7=-16210;D=141562156215156262626215151562626215626215621562151515621562151515156262156262626215151562156215621515151515151562151515156262156215171212121212121212121212;CP=1;SP=4;R=66;O;m0;
-					# MS;P0=-16052;P1=363;P2=-437;P3=-4001;P4=-829;P5=755;D=131452521452145252521452145252521414141452521452145214141414525252145252145252525214141452145214521414141414141452141414145252145252101212121212121212121212;CP=1;SP=3;R=51;O;m1;
-	{
-		name					=> 'Roto',
-		comment				=> 'Roto TX-nM-HCS',
-		id						=> '88',
-		one						=> [1,-2],
-		zero					=> [2,-1],
-		sync					=> [1,-10],				# this is a end marker, but we use this as a start marker
-		clockabs			=> 400,           # ca 400us
-		developId			=> 'y',
-		format				=> 'twostate',	  		
-		preamble			=> 'u88#',				# prepend to converted message	
-		#clientmodule	=> '',
-		#modulematch	=> '',
-		length_min		=> '68',
-		length_max		=> '68',
-	},
+	"84"	=>	## Funk Wetterstation Auriol IAN 283582 Version 06/2017 (Lidl), Modell-Nr.: HG02832D, 09/2018@roobbb
+						# https://github.com/RFD-FHEM/RFFHEM/issues/263
+						# MU;P0=-28796;P1=376;P2=-875;P3=834;P4=220;P5=-632;P6=592;P7=-268;D=0123232324545454545456767454567674567456745674545454545456767676767674567674567676767456;CP=4;R=22;
+						# MU;P0=-28784;P1=340;P2=-903;P3=814;P4=223;P5=-632;P6=604;P7=-248;D=0123232324545454545456767456745456767674545674567454545456745454545456767454545456745676;CP=4;R=22;
+						# MU;P0=-21520;P1=235;P2=-855;P3=846;P4=620;P5=-236;P7=-614;D=012323232454545454545451717451717171745171717171717171717174517171745174517174517174545;CP=1;R=217;
+						## Sempre 92596/65395, Hofer/Aldi, WS97210-1, WS97230-1, WS97210-2, WS97230-2
+						# https://github.com/RFD-FHEM/RFFHEM/issues/223
+						# MU;P0=11916;P1=-852;P2=856;P3=610;P4=-240;P5=237;P6=-610;D=01212134563456563434565634565634343456565634565656565634345634565656563434563456343430;CP=5;R=254;
+						# MU;P0=-30004;P1=815;P2=-910;P3=599;P4=-263;P5=234;P6=-621;D=0121212345634565634345656345656343456345656345656565656343456345634563456343434565656;CP=5;R=5;
+		{
+			name					=> 'IAN283582',
+			comment				=> 'Weatherstation Auriol IAN 283582 / Sempre 92596/65395',
+			id						=> '84',
+			one						=> [3,-1],
+			zero					=> [1,-3],
+			start					=> [4,-4,4,-4,4,-4],
+			clockabs			=> 215, 
+			format				=> 'twostate',
+			preamble			=> 'W84#',						# prepend to converted message
+			postamble			=> '',								# append to converted message
+			clientmodule	=> 'SD_WS',
+			length_min		=> '39',							# das letzte Bit fehlt meistens
+			length_max		=> '40',
+		},
+	"85"	=>	## Funk Wetterstation TFA 35.1140.01 mit Temperatur-/Feuchte- und Windsensor TFA 30.3222.02 09/2018@Iron-R
+						# https://github.com/RFD-FHEM/RFFHEM/issues/266
+						# MU;P0=-509;P1=474;P2=-260;P3=228;P4=718;P5=-745;D=01212303030303012301230123012301230301212121230454545453030303012123030301230303012301212123030301212303030303030303012303012303012303012301212303030303012301230123012301230301212121212454545453030303012123030301230303012301212123030301212303030303030303;CP=3;R=46;O;
+						# MU;P0=-504;P1=481;P2=-254;P3=227;P4=723;P5=-739;P6=-1848;D=01230121212303030121230303030303030453030303012123030301230303012301212303030303030304530303030121230303012303030123012121230303012123030303030303030123030123030123030123012123030303030123012301230123012303012121212364545454530303030121230303012303030123;CP=3;R=45;O;
+						# MU;P0=7944;P1=-724;P2=742;P3=241;P4=-495;P5=483;P6=-248;D=01212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634345656345634343456563421212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634;CP=3;R=47;O;�
+		{
+			name         => 'TFA 30.3222.02',
+			comment      => 'Combisensor for Weatherstation TFA 35.1140.01',
+			id           => '85',
+			one          => [2,-1],
+			zero         => [1,-2],
+			start        => [3,-3,3,-3,3,-3],
+			clockabs     => 250, 
+			format       => 'twostate',
+			preamble     => 'W85#',					# prepend to converted message
+			postamble    => '',							# append to converted message
+			clientmodule => 'SD_WS',
+			length_min   => '64',
+			length_max   => '68',
+		},
+	"86"	=>	## for remote controls:  Novy 840029, CAME TOP 432EV, Neff Transmitter SF01 01319004
+						### CAME TOP 432EV 433,92 MHz für z.B. Drehtor Antrieb:
+						# https://forum.fhem.de/index.php/topic,63370.msg849400.html#msg849400
+						# https://github.com/RFD-FHEM/RFFHEM/issues/151
+						# MU;P0=711;P1=-15288;P4=132;P5=-712;P6=316;P7=-313;D=4565656705656567056567056 16 565656705656567056567056 16 56565670565656705656705616565656705656567056567056165656567056565670565670561656565670565656705656705616565656705656567056567056165656567056565670565670561656565670565656705656705616565656705656567056;CP=6;R=52;
+						# MU;P0=-322;P1=136;P2=-15241;P3=288;P4=-735;P6=723;D=012343434306434343064343430623434343064343430643434306 2343434306434343064343430 623434343064343430643434306234343430643434306434343062343434306434343064343430623434343064343430643434306234343430643434306434343062343434306434343064343430;CP=3;R=27;
+						# MU;P0=-15281;P1=293;P2=-745;P3=-319;P4=703;P5=212;P6=152;P7=-428;D=0 1212121342121213421213421 01 212121342121213421213421 01 21212134212121342121342101212121342121213421213421012121213421212134212134210121243134212121342121342101252526742121213425213421012121213421212134212134210121212134212;CP=1;R=23;
+						# rechteTaste: 0x112 (000100010010), linkeTaste: 0x111 (000100010001), the least significant bits distinguish the keys
+						### remote control Novy 840029 for Novy Pureline 6830 kitchen hood:
+						# https://github.com/RFD-FHEM/RFFHEM/issues/331
+						# light on/off button  # MU;P0=710;P1=353;P2=-403;P4=-761;P6=-16071;D=20204161204120412041204120414141204120202041612041204120412041204141412041202020416120412041204120412041414120412020204161204120412041204120414141204120202041;CP=1;R=40;
+						# plus button          # MU;P0=22808;P1=-24232;P2=701;P3=-765;P4=357;P5=-15970;P7=-406;D=012345472347234723472347234723454723472347234723472347234547234723472347234723472345472347234723472347234723454723472347234723472347234;CP=4;R=39;
+						# minus button         # MU;P0=-8032;P1=364;P2=-398;P3=700;P4=-760;P5=-15980;D=0123412341234123412341412351234123412341234123414123512341234123412341234141235123412341234123412341412351234123412341234123414123;CP=1;R=40;
+						# power button         # MU;P0=-756;P1=718;P2=354;P3=-395;P4=-16056;D=01020202310231310202 42 310231023102310231020202310231310202 42 31023102310231023102020231023131020242310231023102310231020202310231310202;CP=2;R=41;
+						# novy button          # MU;P0=706;P1=-763;P2=370;P3=-405;P4=-15980;D=0123012301230304230123012301230123012303042;CP=2;R=42;
+						### Neff Transmitter SF01 01319004 433,92 MHz for kitchen hood:
+						# https://github.com/RFD-FHEM/RFFHEM/issues/376
+						# MU;P0=706;P1=-160;P2=140;P3=-335;P4=-664;P5=385;P6=-15226;P7=248;D=01210103045303045453030304545453030454530653030453030454530303045454530304747306530304530304545303030454545303045453065303045303045453030304545453030454530653030453030454530303045454530304545306530304530304545303030454545303045453065303045303045453030304;CP=5;O;
+						# MU;P0=-15222;P1=379;P2=-329;P3=712;P6=-661;D=30123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616161232361232301232361232361612323236161612323612323012323612323616123232361616123236123230123236123236161232323616;CP=1;O;
+						# MU;P0=705;P1=-140;P2=-336;P3=-667;P4=377;P5=-15230;P6=248;D=01020342020343420202034343420202020345420203420203434202020343434202020203654202034202034342020203434342020202034542020342020343420202034343420202020345420203420203434202020343434202020203454202034202034342020203434342020202034542020342020343420202034343;CP=4;O;
+						# MU;P0=704;P1=-338;P2=-670;P3=378;P4=-15227;P5=244;D=01023231010102323231010102310431010231010232310101023232310101025104310102310102323101010232323101010231043101023101023231010102323231010102310431010231010232310101023232310101023104310102310102323101010232323101010231043101023101023231010102323231010102;CP=3;O;
+						# MU;P0=-334;P1=709;P2=-152;P3=-663;P4=379;P5=-15226;P6=250;D=01210134010134340101013434340101340134540101340101343401010134343401013601365401013401013434010101343434010134013454010134010134340101013434340101340134540101340101343401010134343401013401345401013401013434010101343434010134013454010134010134340101013434;CP=4;O;
+		{
+			name					=> 'CAME|Novy|Neff',
+			comment				=> 'CAME TOP 432EV, Novy 840029, Neff SF01 01319004',
+			id						=> '86',
+			one						=> [-2,1],
+			zero					=> [-1,2],
+			start					=> [-44,1],
+			clockabs			=> 350,
+			format				=> 'twostate',
+			preamble			=> 'P86#',				# prepend to converted message
+			clientmodule	=> 'SD_UT',
+			#modulematch	=> '^P86#.*',
+			length_min		=> '12',
+			length_max		=> '18',
+		},
+	"87"	=>	## JAROLIFT Funkwandsender TDRC 16W / TDRCT 04W
+						# https://github.com/RFD-FHEM/RFFHEM/issues/380
+						# MS;P1=1524;P2=-413;P3=388;P4=-3970;P5=-815;P6=778;P7=-16024;D=34353535623562626262626235626262353562623535623562626235356235626262623562626262626262626262626262623535626235623535353535626262356262626262626267123232323232323232323232;CP=3;SP=4;R=226;O;m2;
+						# MS;P0=-15967;P1=1530;P2=-450;P3=368;P4=-3977;P5=-835;P6=754;D=34353562623535623562623562356262626235353562623562623562626235353562623562626262626262626262626262623535626235623535353535626262356262626262626260123232323232323232323232;CP=3;SP=4;R=229;O;
+		{
+			name					=> 'JAROLIFT',
+			comment				=> 'JAROLIFT TDRC_16W / TDRCT_04W',
+			id						=> '87',
+			one						=> [1,-2],
+			zero					=> [2,-1],
+			sync					=> [1,-10],				# this is a end marker, but we use this as a start marker
+			clockabs			=> 400,						# ca 400us
+			developId			=> 'y',
+			format				=> 'twostate',
+			preamble			=> 'u87#',				# prepend to converted message	
+			#clientmodule	=> '',
+			#modulematch	=> '',
+			length_min		=> '72',					# 72
+			length_max		=> '85',					# 85
+		},
+	"88"	=>	## Roto Dachfensterrolladen | Aurel Fernbedienung "TX-nM-HCS" (HCS301 Chip) | three buttons -> up, Stop, down
+						# https://forum.fhem.de/index.php/topic,91244.0.html
+						# MS;P1=361;P2=-435;P4=-4018;P5=-829;P6=759;P7=-16210;D=141562156215156262626215151562626215626215621562151515621562151515156262156262626215151562156215621515151515151562151515156262156215171212121212121212121212;CP=1;SP=4;R=66;O;m0;
+						# MS;P0=-16052;P1=363;P2=-437;P3=-4001;P4=-829;P5=755;D=131452521452145252521452145252521414141452521452145214141414525252145252145252525214141452145214521414141414141452141414145252145252101212121212121212121212;CP=1;SP=3;R=51;O;m1;
+		{
+			name					=> 'Roto',
+			comment				=> 'Roto TX-nM-HCS',
+			id						=> '88',
+			one						=> [1,-2],
+			zero					=> [2,-1],
+			sync					=> [1,-10],				# this is a end marker, but we use this as a start marker
+			clockabs			=> 400,						# ca 400us
+			developId			=> 'y',
+			format				=> 'twostate',
+			preamble			=> 'u88#',				# prepend to converted message	
+			#clientmodule	=> '',
+			#modulematch	=> '',
+			length_min		=> '68',
+			length_max		=> '68',
+		},
 );


### PR DESCRIPTION
- Space replaced by tab for uniform organization and minimization of file size
- revised Comments | doc ID86 revised
- ID14 commented out old def, after revised FW SIGNALduino decode other messagetyp (ID 79) https://github.com/RFD-FHEM/RFFHEM/issues/367
- ID 88 length corrected

* **What is the current behavior?** (You can also link to an open issue here)
many spaces

* **What is the new behavior (if this is a feature change)?**
tab for uniform organization and minimization of file size
correct length ID88