### PR TITLE
Update start id76 

### DIFF
--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -1623,7 +1623,7 @@
 			id						=> '76',
 			one						=> [1.2,-2],			# 120,-200
 			zero					=> [],						# existiert nicht
-			start					=> [4.5,-2],			# 450,-200 Starsequenz
+			start					=> [4.5,-2,4.5,-2,4.5,-2,4.5,-2],			# 450,-200 Starsequenz
 			clockabs			=> 100,
 			format				=> 'twostate',		# not used now
 			clientmodule	=> 'SD_UT',


### PR DESCRIPTION
modified start preamble, to allow correct message generated via sendMSG

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

start sequence is corrected

* **What is the current behavior?** (You can also link to an open issue here)

the start sequence is not correct, changing the state of the leds will not work 

* **What is the new behavior (if this is a feature change)?**

the start sequence is corrected, so it is correctly used when sending a message via sendMsg

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
