### PR TITLE
signalduino_protocols.hash

### DIFF
--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -1941,13 +1941,13 @@
 		{
 			name							=> 'm-fs300',
 			comment							=> 'IT remote control mumbi FS300, MX-RCS250',
-			id								=> '3',
+			id								=> '90',
 			one								=> [3,-1],
 			zero							=> [1,-3],
 			sync							=> [1,-38],
 			clockabs						=> -1,					# -1=auto	
 			format							=> 'twostate',			# not used now
-			preamble						=> 'u#',			
+			preamble						=> 'u#90',			
 			length_min						=> '33',
 			length_max						=> '36',		
 			developId						=> 'p',		

--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -171,6 +171,7 @@
 			length_max				=> '24',				# Don't know maximal lenth of a valid message
 			postDemodulation	=> \&SIGNALduino_bit2itv1,
 		},
+		
 	"4"	=>	## arctech2
 					# need more Device Infos / User Message
 		{
@@ -1931,4 +1932,26 @@
 			length_min   => '40',
 			length_max   => '40',
 		},
+
+	"90"	=>	## socket remote -  mumbi m-fs300 / manax MX-RCS250
+						# MS;P0=-9964;P1=273;P4=-866;P5=792;P6=-343;D=10145614141414565656561414561456561414141456565656561456141414145614;CP=1;SP=0;R=35;O;m2; //A  AN
+						# MS;P0=300;P1=-330;P2=-10160;P3=804;P7=-840;D=02073107070707313131310707310731310707070731313107310731070707070707;CP=0;SP=2;R=23;O;m1 //A  AUS
+						# MS;P1=260;P2=-873;P3=788;P4=-351;P6=-10157;D=16123412121212343434341212341234341212121234341234341234121212341212;CP=1;SP=6;R=21;O;m2; // B AN
+						# need more Device Infos / User Message
+		{
+			name							=> 'm-fs300',
+			comment							=> 'IT remote control mumbi FS300, MX-RCS250',
+			id								=> '3',
+			one								=> [3,-1],
+			zero							=> [1,-3],
+			sync							=> [1,-38],
+			clockabs						=> -1,					# -1=auto	
+			format							=> 'twostate',			# not used now
+			preamble						=> 'u#',			
+			length_min						=> '33',
+			length_max						=> '36',		
+			developId						=> 'p',		
+		},
+
+
 );

--- a/controls_signalduino.txt
+++ b/controls_signalduino.txt
@@ -14,7 +14,7 @@ UPD 2018-12-10_21:14:26 48295   FHEM/14_SD_WS.pm
 UPD 2018-07-04_21:56:16 37910   FHEM/41_OREGON.pm
 UPD 2018-12-10_22:45:43 16990   FHEM/90_SIGNALduino_un.pm
 UPD 2017-11-12_23:12:44 40243   FHEM/98_Dooya.pm
-UPD 2018-12-18_08:29:45 103619  FHEM/lib/signalduino_protocols.hash
+UPD 2018-12-19_00:49:13 104584  FHEM/lib/signalduino_protocols.hash
 MOV FHEM/firmware/SIGNALduino_nano328.hex unused
 MOV FHEM/firmware/SIGNALduino_nanoCC1101.hex unused
 MOV FHEM/firmware/SIGNALduino_promini328.hex unused

--- a/controls_signalduino.txt
+++ b/controls_signalduino.txt
@@ -14,7 +14,7 @@ UPD 2018-12-10_21:14:26 48295   FHEM/14_SD_WS.pm
 UPD 2018-07-04_21:56:16 37910   FHEM/41_OREGON.pm
 UPD 2018-12-10_22:45:43 16990   FHEM/90_SIGNALduino_un.pm
 UPD 2017-11-12_23:12:44 40243   FHEM/98_Dooya.pm
-UPD 2018-12-19_08:55:02 104587  FHEM/lib/signalduino_protocols.hash
+UPD 2018-12-19_10:51:52 104739  FHEM/lib/signalduino_protocols.hash
 MOV FHEM/firmware/SIGNALduino_nano328.hex unused
 MOV FHEM/firmware/SIGNALduino_nanoCC1101.hex unused
 MOV FHEM/firmware/SIGNALduino_promini328.hex unused

--- a/controls_signalduino.txt
+++ b/controls_signalduino.txt
@@ -14,7 +14,7 @@ UPD 2018-12-10_21:14:26 48295   FHEM/14_SD_WS.pm
 UPD 2018-07-04_21:56:16 37910   FHEM/41_OREGON.pm
 UPD 2018-12-10_22:45:43 16990   FHEM/90_SIGNALduino_un.pm
 UPD 2017-11-12_23:12:44 40243   FHEM/98_Dooya.pm
-UPD 2018-12-19_00:49:13 104584  FHEM/lib/signalduino_protocols.hash
+UPD 2018-12-19_08:55:02 104587  FHEM/lib/signalduino_protocols.hash
 MOV FHEM/firmware/SIGNALduino_nano328.hex unused
 MOV FHEM/firmware/SIGNALduino_nanoCC1101.hex unused
 MOV FHEM/firmware/SIGNALduino_promini328.hex unused


### PR DESCRIPTION
Added new protocol (90) for manax MX-RCS250 and mumbi fs-300 style remotes

https://forum.fhem.de/index.php/topic,94327.15.html

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

demodulate MANAX MX-RCS250 and mumbi fs300 remotes

* **What is the current behavior?** (You can also link to an open issue here)

data does not match any protocol

* **What is the new behavior (if this is a feature change)?**

protocol 90 matches the data from these sockets

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
https://forum.fhem.de/index.php/topic,94327.15.html