### PR TITLE
Update signalduino_protocols.hash

### DIFF
--- a/FHEM/lib/signalduino_protocols.hash
+++ b/FHEM/lib/signalduino_protocols.hash
@@ -1350,7 +1350,7 @@
 			knownFreqs      => '',
 			clockrange			=> [460,520],			# min , max
 			format					=> 'manchester',	# tristate can't be migrated from bin into hex!
-			clientmodule		=> '',
+			clientmodule		=> 'SD_WS',
 			modulematch			=> '^W58*',
 			preamble				=> 'W58#',
 			length_min			=> '54',
@@ -1868,11 +1868,13 @@
 			knownFreqs		=> '',
 			developId			=> 'm',
 			dispatchBin		=> '1',
+			paddingbits		=> '1',      # disable padding
 			one						=> [1,-2],			# on=400us, off=800us
 			zero					=> [2,-1],			# on=800us, off=400us
 			float					=> [1,-8],			# on=400us, off=3200us. the preamble and each 10bit word has one [1,-8] in front
 			pause					=> [1,-1],			# preamble (5x)
 			clockabs			=> 400,					# 400us
+			format				=> 'twostate',
 			preamble			=> 'P82#',			# prepend our protocol number to converted message
 			clientmodule	=> 'Fernotron',
 			length_min		=> '100',				# actual 120 bit (12 x 10bit words to decode 6 bytes data), but last 20 are for checksum

--- a/controls_signalduino.txt
+++ b/controls_signalduino.txt
@@ -14,7 +14,7 @@ UPD 2019-01-09_22:11:35 50156   FHEM/14_SD_WS.pm
 UPD 2018-07-04_21:56:16 37910   FHEM/41_OREGON.pm
 UPD 2019-01-02_22:11:04 17028   FHEM/90_SIGNALduino_un.pm
 UPD 2017-11-12_23:12:44 40243   FHEM/98_Dooya.pm
-UPD 2019-01-10_00:13:05 115549  FHEM/lib/signalduino_protocols.hash
+UPD 2019-01-14_19:41:36 115629  FHEM/lib/signalduino_protocols.hash
 MOV FHEM/firmware/SIGNALduino_nano328.hex unused
 MOV FHEM/firmware/SIGNALduino_nanoCC1101.hex unused
 MOV FHEM/firmware/SIGNALduino_promini328.hex unused


### PR DESCRIPTION
bei ID 58, `clientmodule => 'SD_WS' `zugefügt
bei ID 82 hat paddingbits und format gefehlt. Das fehlende Format hat ein warning verursacht.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
