### PR TITLE
Update 00_Signalduino.pm: Halbe letzte Bits bei MS rekonstruieren

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -2072,8 +2072,8 @@ SIGNALduino_Parse_MS($$$$%)
 
 			$valid = $valid && ($pstr=SIGNALduino_PatternExists($hash,\@{$ProtocolListSIGNALduino{$id}{one}},\%patternList,\$rawData)) >=0;
 			Debug "Found matched one with indexes: ($pstr)" if ($debug && $valid);
-			$patternLookupHash{$pstr}="1" if ($valid); ## Append Sync to our lookuptable
-			$endPatternLookupHash{substr($pstr,0,length($pstr)-1)}="1" if ($valid); ## Append Sync to our lookuptable
+			$patternLookupHash{$pstr}="1" if ($valid); ## Append one to our lookuptable
+			$endPatternLookupHash{substr($pstr,0,length($pstr)-1)}="1" if ($valid); ## Append one to our endbit lookuptable
 			#SIGNALduino_Log3 $name, 4, "$name: Sync 1 ".$pstr." -> ".substr($pstr,0,length($pstr)-1)." eingetragen"  if ($valid);
 			#Debug "added $pstr " if ($debug && $valid);
 			Debug "one pattern not found" if ($debug && !$valid);
@@ -2127,7 +2127,7 @@ SIGNALduino_Parse_MS($$$$%)
 				if (exists $patternLookupHash{$sig_str}) { ## Add the bits to our bit array
 					push(@bit_msg,$patternLookupHash{$sig_str})
 				} elsif ((length($sig_str)< $signal_width ) && (exists $endPatternLookupHash{$sig_str})) {
-					SIGNALduino_Log3 $name, 5, "$name: letztes Bit rekonstruiert.";
+					SIGNALduino_Log3 $name, 5, "$name: last bit reconstructed";
 					push(@bit_msg,$endPatternLookupHash{$sig_str})
 				} else {
 					SIGNALduino_Log3 $name, 5, "$name: Found wrong signalpattern, catched ".scalar @bit_msg." bits, aborting demodulation";


### PR DESCRIPTION
Bei MS-Daten kann es sein, dass das letzte Bit nur teilweise in dem Datensatz repräsentiert ist. Sollte sich in diesem Fall aus dem letzten Zeichen und den Protokolldefinitionen One und Zero eine eindeutige Zuordnung ergeben, so wird diese Zuordnung dekodiert

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
