### PR TITLE
Some tests for SIGNALduino_Define defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test: deploylocal
 	git --no-pager diff --name-only ${TRAVIS_COMMIT_RANGE} | egrep "\.pm" | xargs -I@ echo -select @ | xargs --no-run-if-empty perl /opt/fhem/contrib/commandref_join.pl 
 	@echo === running unit tests ===
 	test/test-runner.sh test_modules
+	test/test-runner.sh test_defineDefaults
 	test/test-runner.sh test_callsub_1
 	test/test-runner.sh test1
 	test/test-runner.sh test3

--- a/test/test_defineDefaults-definition.txt
+++ b/test/test_defineDefaults-definition.txt
@@ -1,0 +1,17 @@
+defmod test_defineDefaults UnitTest dummyDuino (
+ {
+	CommandDefMod(undef,"-temporary testDuino SIGNALduino none");
+ 	
+ 	
+ 	subtest 'Check internal defaults ' => sub {
+		plan tests => 4;
+		my $name ="testDuino";
+			
+	 	is(InternalVal($name,"DeviceName", undef),"none","check DeviceName");
+	 	is(InternalVal($name,"DMSG", undef),"nothing","check DMSG");
+	 	is(InternalVal($name,"LASTDMSG", undef),"nothing","check LASTDMSG");
+	 	is(InternalVal($name,"versionmodul", undef),SDUINO_VERSION,"check versionmodul");
+	}; 
+
+ };
+);


### PR DESCRIPTION
Added new test which checks some of the defaults set in SIGNALduino_Define

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This adds tests to verify SIGNALduino_Define sub

* **What is the current behavior?** (You can also link to an open issue here)

SIGNALduino_Define isn't covered in a test

* **What is the new behavior (if this is a feature change)?**


Some defaults set in SIGNALduino_Define are covered

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

