### PR TITLE
14_SD_Keeloq.pm - fix PERL WARNING

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,4 +1,6 @@
 27.02.2019
+ 14_SD_Keeloq.pm: fix PERL WARNING if hlen a other typ of device
+27.02.2019
  14_SD_UT.pm: added model LIBRA TR-502MSV [receiver RC-710DX|RC-710] (LIDL)
 26.02.2019
  signalduino_protocols.pm: set reconstructBit on ID87 + ID91 +91.1 | remove developId status ID 73

--- a/CHANGED
+++ b/CHANGED
@@ -1,5 +1,5 @@
 27.02.2019
- 14_SD_Keeloq.pm: fix PERL WARNING if hlen a other typ of device
+ 14_SD_Keeloq.pm: fix PERL WARNING if hlen a other typ of device, readings rename to FHEM standard (battery), revised doc
 27.02.2019
  14_SD_UT.pm: added model LIBRA TR-502MSV [receiver RC-710DX|RC-710] (LIDL)
 26.02.2019

--- a/FHEM/14_SD_Keeloq.pm
+++ b/FHEM/14_SD_Keeloq.pm
@@ -785,8 +785,8 @@ sub Parse($$) {
 		}
 	### Roto ###
 	} elsif ($model eq "Roto" || $model eq "Waeco_MA650_TX") {
-		$VLOW = reverse (substr ($bitData , 64 , 1));
-		$RPT = reverse (substr ($bitData , 65 , 1));	
+		$VLOW = substr ($bitData , 64 , 1);
+		$RPT = substr ($bitData , 65 , 1);
 
 		my $binsplit = SD_Keeloq_binsplit_Roto($bitData);
 
@@ -946,7 +946,9 @@ sub Parse($$) {
 	Log3 $name, 5, "$ioname: SD_Keeloq_Parse - user_modus                           = $modus";
 	Log3 $name, 5, "$ioname: SD_Keeloq_Parse - user_info                            = $info";
 	Log3 $name, 5, "######## DEBUG END ########\n";
-
+	
+	$VLOW = $VLOW eq "0" ? "ok" : "low" if (defined $VLOW);		# only chip HCS301 - Roto | Waeco_MA650_TX
+	$RPT = $RPT eq "0" ? "no" : "yes" if (defined $RPT);			# only chip HCS301 - Roto | Waeco_MA650_TX
 
 	readingsBeginUpdate($hash);
 	readingsBulkUpdate($hash, "button", $button);
@@ -955,8 +957,8 @@ sub Parse($$) {
 	readingsBulkUpdate($hash, "channel_control", $group_value) if (defined $group_value);		# JaroLift
 	readingsBulkUpdate($hash, "counter_receive", $counter_decr) if (defined $counter_decr);
 	readingsBulkUpdate($hash, "last_digits", $bit8to15) if (defined $bit8to15);							# JaroLift
-	readingsBulkUpdate($hash, "indicator_repeat", $RPT) if (defined $RPT);									# Roto | Waeco_MA650_TX
-	readingsBulkUpdate($hash, "indicator_voltage_LOW", $VLOW) if (defined $VLOW);						# Roto | Waeco_MA650_TX
+	readingsBulkUpdate($hash, "repeat_message", $RPT) if (defined $RPT);										# Roto | Waeco_MA650_TX
+	readingsBulkUpdate($hash, "batteryState", $VLOW) if (defined $VLOW);										# Roto | Waeco_MA650_TX
 	readingsBulkUpdate($hash, "serial_receive", $serialWithoutCh, 0);
 	readingsBulkUpdate($hash, "state", $state);
 	readingsBulkUpdate($hash, "user_modus", $modus);
@@ -1555,7 +1557,7 @@ sub SD_Keeloq_attr2htmlButtons($$$$$) {
 		Anzeigeart (UserInterface) in FHEM (Standard aus)
 		<br>
 		<ul><li>Mehrzeilig:<br>
-		Ausgew&auml;hlte Anzahl an Kan&auml;len wird Tabellarisch statt des STATE-Icons angezeigt</li>
+		Ausgew&auml;hlte Anzahl an Kan&auml;len wird tabellarisch statt des STATE-Icons angezeigt</li>
 		<li>Einzeilig:<br>
 		Es wird nur eine Zeile mit einem Auswahlfeld f&uuml;r den Kanal angezeigt.</li>
 		<li>aus:<br>
@@ -1580,7 +1582,7 @@ sub SD_Keeloq_attr2htmlButtons($$$$$) {
 		</li>
 		<br>
 		<li><a name="Repeats"><b>Repeats</b></a><br>
-		Mit diesem Attribut kann angepasst werden, wie viele Wiederholungen sendet werden. (Standard 3)
+		Mit diesem Attribut kann angepasst werden, wie viele Wiederholungen gesendet werden. (Standard 3)
 		</li>
 	</ul>
 	<br><br>

--- a/FHEM/14_SD_Keeloq.pm
+++ b/FHEM/14_SD_Keeloq.pm
@@ -686,6 +686,8 @@ sub Parse($$) {
 	} else {
 		Log3 $iohash, 4, "$ioname: SD_Keeloq_Parse Unknown device with wrong length of $hlen! (rawData=$rawData)";
 		return "";
+	}
+
 	$modules{SD_Keeloq}{defptr}{ioname} = $ioname;
 	my $def = $modules{SD_Keeloq}{defptr}{$devicedef};
 

--- a/FHEM/14_SD_Keeloq.pm
+++ b/FHEM/14_SD_Keeloq.pm
@@ -10,8 +10,8 @@
 # KeeLoq is a registered trademark of Microchip Technology Inc.
 #
 ######################################################################################################################
-# !!! ToDo´s !!!
-#		-
+# !!! notes !!! | date: 20190304
+#		- last change: fix PERL WARNING line "my $def = $modules{SD_Keeloq}{defptr}{$devicedef};"
 #		-
 ######################################################################################################################
 
@@ -683,8 +683,9 @@ sub Parse($$) {
 		$serialWithoutCh = reverse (substr ($bitData , 36 , 24));						# 24bit serial without last 4 bit ### Serial without last nibble, fix at device at every channel
 		$serialWithoutCh = sprintf ("%06s", sprintf ("%X", oct( "0b$serialWithoutCh" )));
 		$devicedef = $serialWithoutCh;
-	}
-
+	} else {
+		Log3 $iohash, 4, "$ioname: SD_Keeloq_Parse Unknown device with wrong length of $hlen! (rawData=$rawData)";
+		return "";
 	$modules{SD_Keeloq}{defptr}{ioname} = $ioname;
 	my $def = $modules{SD_Keeloq}{defptr}{$devicedef};
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [X] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fix PERL WARNING if hlen a other typ of device


* **What is the current behavior?** (You can also link to an open issue here)
- user with other hlen on this protocol definition gets one PERL WARNING