### PR TITLE
unittest  to verify set command sendMsg a little bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ test: deploylocal
 	test/test-runner.sh test_sub_SIGNALduino_OSV2
 	test/test-runner.sh test_sub_MCTFA
 	test/test-runner.sh test_sub_SIGNALduino_getAttrDevelopment
+	test/test-runner.sh test_set_sendMsg
+	test/test-runner.sh test_read
 	test/test-runner.sh test_SDWS07
 	@echo === finished unit tests ===
 	sudo timeout 30 killall -vw perl || sudo killall -vws9 perl

--- a/test/test_set_sendMsg-definition.txt
+++ b/test/test_set_sendMsg-definition.txt
@@ -4,27 +4,38 @@ defmod test_set_sendMsg UnitTest dummyDuino
     my %mockData = (
     '0'    => 
 		{	
+			testname=>  "ID: 0",
 			input	=>	"P0#0101#R3#C500",
 			output 	=> 	'SR;R=3;P0=500;P1=-8000;P2=-3500;P3=-1500;D=0103020302;',
 		},
     '17'    => 
 		{	
+			testname=>  "ID: 17",
 			input	=>	"P17#0101#R3#C500",
 			output 	=> 	'SR;R=3;P0=500;P1=-5000;P2=-2500;P3=-500;P4=-20000;D=01030202030302020304;',
 		},
 		 
     '29'    => 
 		{	
+			testname=>  "ID: 29",
 			input	=>	"P29#0xF7E#R4",
 			output 	=> 	'SR;R=4;P0=-8225;P1=235;P2=-470;P3=-235;P4=470;D=01212121213421212121212134;',
 		},
     '43'    => 
 		{	
+			testname=>  "ID: 43 with explicit frequency",
 			input	=>	"P43#0101#R3#C500#F10AB85550A",
+			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
+		},
+    '43a'    => 
+		{	
+			testname=>  "ID: 43 with default frequency",
+			input	=>	"P43#0101#R3#C500",
 			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
 		},
     '72'    => 
 		{	
+			testname=>  "ID: 72",
 			input	=>	"P72#0101#R3#C500",
 			output 	=> 	'SR;R=3;P0=7000;P1=-2200;P2=1000;P3=-600;P4=500;P5=-1100;D=0145234523;',
 		},
@@ -33,9 +44,9 @@ defmod test_set_sendMsg UnitTest dummyDuino
 	my $mock = Mock::Sub->new;
  	my $AddSendQueuefn = $mock->mock('SIGNALduino_AddSendQueue');
 
-	foreach my $id (qw/0 17 29 43 72/) 
+	foreach my $id (qw/0 17 29 43 43a 72/) 
 	{
-		subtest "checking set sendMsg id: $id " => sub {
+		subtest "checking set sendMsg $mockData{$id}{testname} " => sub {
 			plan tests => 1;	
 			$AddSendQueuefn->reset();
 			

--- a/test/test_set_sendMsg-definition.txt
+++ b/test/test_set_sendMsg-definition.txt
@@ -20,7 +20,7 @@ defmod test_set_sendMsg UnitTest dummyDuino
 		},
     '43'    => 
 		{	
-			input	=>	"P43#0101#R3#C500",
+			input	=>	"P43#0101#R3#C500#F10AB85550A",
 			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
 		},
     '72'    => 

--- a/test/test_set_sendMsg-definition.txt
+++ b/test/test_set_sendMsg-definition.txt
@@ -25,13 +25,13 @@ defmod test_set_sendMsg UnitTest dummyDuino
 		{	
 			testname=>  "ID: 43 with explicit frequency",
 			input	=>	"P43#0101#R3#C500#F10AB85550A",
-			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
+			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;F=10AB85550A;',
 		},
     '43a'    => 
 		{	
 			testname=>  "ID: 43 with default frequency",
 			input	=>	"P43#0101#R3#C500",
-			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
+			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;F=10AB85550A;',
 		},
     '72'    => 
 		{	
@@ -43,13 +43,13 @@ defmod test_set_sendMsg UnitTest dummyDuino
 
 	my $mock = Mock::Sub->new;
  	my $AddSendQueuefn = $mock->mock('SIGNALduino_AddSendQueue');
+	$targetHash->{version} = "dummy cc1101";
 
 	foreach my $id (qw/0 17 29 43 43a 72/) 
 	{
 		subtest "checking set sendMsg $mockData{$id}{testname} " => sub {
 			plan tests => 1;	
 			$AddSendQueuefn->reset();
-			
 			
 			SIGNALduino_Set($targetHash,$target,"sendMsg",$mockData{$id}{input});
 			if ($AddSendQueuefn->called)

--- a/test/test_set_sendMsg-definition.txt
+++ b/test/test_set_sendMsg-definition.txt
@@ -12,6 +12,12 @@ defmod test_set_sendMsg UnitTest dummyDuino
 			input	=>	"P17#0101#R3#C500",
 			output 	=> 	'SR;R=3;P0=500;P1=-5000;P2=-2500;P3=-500;P4=-20000;D=01030202030302020304;',
 		},
+		 
+    '29'    => 
+		{	
+			input	=>	"P29#0xF7E#R4",
+			output 	=> 	'SR;R=4;P0=-8225;P1=235;P2=-470;P3=-235;P4=470;D=01212121213421212121212134;',
+		},
     '43'    => 
 		{	
 			input	=>	"P43#0101#R3#C500",
@@ -27,7 +33,7 @@ defmod test_set_sendMsg UnitTest dummyDuino
 	my $mock = Mock::Sub->new;
  	my $AddSendQueuefn = $mock->mock('SIGNALduino_AddSendQueue');
 
-	foreach my $id (qw/0 17 43 72/) 
+	foreach my $id (qw/0 17 29 43 72/) 
 	{
 		subtest "checking set sendMsg id: $id " => sub {
 			plan tests => 1;	

--- a/test/test_set_sendMsg-definition.txt
+++ b/test/test_set_sendMsg-definition.txt
@@ -1,0 +1,48 @@
+defmod test_set_sendMsg UnitTest dummyDuino 
+(
+ {
+    my %mockData = (
+    '0'    => 
+		{	
+			input	=>	"P0#0101#R3#C500",
+			output 	=> 	'SR;R=3;P0=500;P1=-8000;P2=-3500;P3=-1500;D=0103020302;',
+		},
+    '17'    => 
+		{	
+			input	=>	"P17#0101#R3#C500",
+			output 	=> 	'SR;R=3;P0=500;P1=-5000;P2=-2500;P3=-500;P4=-20000;D=01030202030302020304;',
+		},
+    '43'    => 
+		{	
+			input	=>	"P43#0101#R3#C500",
+			output 	=> 	'SC;R=3;SR;P0=-2560;P1=2560;P3=-640;D=10101010101010113;SM;C=895;D=0101;',
+		},
+    '72'    => 
+		{	
+			input	=>	"P72#0101#R3#C500",
+			output 	=> 	'SR;R=3;P0=7000;P1=-2200;P2=1000;P3=-600;P4=500;P5=-1100;D=0145234523;',
+		},
+	);
+
+	my $mock = Mock::Sub->new;
+ 	my $AddSendQueuefn = $mock->mock('SIGNALduino_AddSendQueue');
+
+	foreach my $id (qw/0 17 43 72/) 
+	{
+		subtest "checking set sendMsg id: $id " => sub {
+			plan tests => 1;	
+			$AddSendQueuefn->reset();
+			
+			
+			SIGNALduino_Set($targetHash,$target,"sendMsg",$mockData{$id}{input});
+			if ($AddSendQueuefn->called)
+			{
+				is( ($AddSendQueuefn->called_with)[1], $mockData{$id}{output}, 'check send command send to SIGNALduino_AddSendQueue' ) || diag(explain $AddSendQueuefn);
+			} 
+		};
+	
+	};
+		
+ }
+);
+    


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It will test if the set command sendMsg will generate the desired command


* **What is the current behavior?** (You can also link to an open issue here)

There is currently no test to verify this section of our code

* **What is the new behavior (if this is a feature change)?**

some conditons of our code a verified

Test will verify via following protocol  IDs:
0 
17 
43 
7

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
