### PR TITLE
new Internal - LAST_Protocol_ID

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,4 +1,6 @@
 21.04.2019
+ 00_SIGNALduino.pm: added new internal, which will return LAST_Protocol_ID dispatch
+21.04.2019
  14_SD_RSL.pm: change set loglevel from 4 to 3
 15.04.2019
  14_SD_WS.pm: check protocol 33 added

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -356,7 +356,7 @@ SIGNALduino_Define($$)
   
   $hash->{DMSG}="nothing";
   $hash->{LASTDMSG} = "nothing";
-	$hash->{LAST_Protocol_ID} = "nothing";
+	$hash->{LASTDMSGID} = "nothing";
   $hash->{TIME}=time();
   $hash->{versionmodul} = SDUINO_VERSION;
   $hash->{versionProtocols} = lib::SD_Protocols::getProtocolVersion();
@@ -1945,6 +1945,7 @@ sub SIGNALduno_Dispatch($$$$$)
 			SIGNALduino_Log3 $name, SDUINO_DISPATCH_VERBOSE, "$name Dispatch: $dmsg, test ungleich: disabled";
 		}
 		$hash->{LASTDMSG} = $dmsg;
+		$hash->{LASTDMSGID} = $id;
 	}
 
    if ($DMSGgleich) {
@@ -2184,7 +2185,6 @@ SIGNALduino_Parse_MS($$$$%)
 			if ( SIGNALduino_moduleMatch($name,$id,$dmsg) == 1)
 			{
 				$message_dispatched++;
-				$hash->{LAST_Protocol_ID} = $id;
 				SIGNALduino_Log3 $name, 4, "$name: Decoded matched MS Protocol id $id dmsg $dmsg length " . scalar @bit_msg . " $rssiStr";
 				SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 			} 
@@ -2444,7 +2444,6 @@ sub SIGNALduino_Parse_MU($$$$@)
 				if ( SIGNALduino_moduleMatch($name,$id,$dmsg) == 1)
 				{
 					$nrDispatch++;
-					$hash->{LAST_Protocol_ID} = $id;
 					SIGNALduino_Log3 $name, 4, "$name: Decoded matched MU Protocol id $id dmsg $dmsg length $bit_length dispatch($nrDispatch/". AttrVal($name,'maxMuMsgRepeat', 4) . ")$rssiStr";
 					SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 					if ( $nrDispatch == AttrVal($name,"maxMuMsgRepeat", 4))
@@ -2569,7 +2568,6 @@ SIGNALduino_Parse_MC($$$$@)
 						}
 						SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 						$message_dispatched=1;
-						$hash->{LAST_Protocol_ID} = $id;
 					}
 				} else {
 					$res="undef" if (!defined($res));
@@ -4579,6 +4577,7 @@ sub SIGNALduino_githubParseHttpResponse($$$)
 	<a name="SIGNALduinointernals"></a>
 	<b>Internals</b>
 	<ul>
+		<li><b>LASTDMSGID</b>: This shows the last dispatched Protocol ID.</li>
 		<li><b>IDsNoDispatch</b>: Here are protocols entryls listed by their numeric id for which not communication to a logical module is enabled. To enable, look at the menu option <a href="#SIGNALduinoDetail">Display protocollist</a>.</li>
 		<li><b>versionmodule</b>: This shows the version of the SIGNALduino FHEM module itself.</li>
 		<li><b>version</b>: This shows the version of the SIGNALduino microcontroller.</li>
@@ -4990,12 +4989,13 @@ When set to 1, the internal "RAWMSG" will not be updated with the received messa
 	<a name="SIGNALduinointernals"></a>
 	<b>Internals</b>
 	<ul>
+		<li><b>LASTDMSGID</b>: Hier wird die zuletzt dispatchte Protocol ID angezeigt.</li>
 		<li><b>IDsNoDispatch</b>: Hier werden protokoll Eintr&auml;ge mit ihrer numerischen ID aufgelistet, f&ouml;r welche keine Weitergabe von Daten an logische Module aktiviert wurde. Um die weiterhabe zu aktivieren, kann die Me&uuml;option <a href="#SIGNALduinoDetail">Display protocollist</a> verwendet werden.</li>
 		<li><b>versionmodule</b>: Hier wird die Version des SIGNALduino FHEM Modules selbst angezeigt.</li>
 		<li><b>version</b>: Hier wird die Version des SIGNALduino microcontrollers angezeigt.</li>
 	</ul>
-	
-					  
+
+
 	<a name="SIGNALduinoset"></a>
 	<b>SET</b>
 	<ul>

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -356,6 +356,7 @@ SIGNALduino_Define($$)
   
   $hash->{DMSG}="nothing";
   $hash->{LASTDMSG} = "nothing";
+	$hash->{LAST_Protocol_ID} = "nothing";
   $hash->{TIME}=time();
   $hash->{versionmodul} = SDUINO_VERSION;
   $hash->{versionProtocols} = lib::SD_Protocols::getProtocolVersion();
@@ -2183,6 +2184,7 @@ SIGNALduino_Parse_MS($$$$%)
 			if ( SIGNALduino_moduleMatch($name,$id,$dmsg) == 1)
 			{
 				$message_dispatched++;
+				$hash->{LAST_Protocol_ID} = $id;
 				SIGNALduino_Log3 $name, 4, "$name: Decoded matched MS Protocol id $id dmsg $dmsg length " . scalar @bit_msg . " $rssiStr";
 				SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 			} 
@@ -2442,6 +2444,7 @@ sub SIGNALduino_Parse_MU($$$$@)
 				if ( SIGNALduino_moduleMatch($name,$id,$dmsg) == 1)
 				{
 					$nrDispatch++;
+					$hash->{LAST_Protocol_ID} = $id;
 					SIGNALduino_Log3 $name, 4, "$name: Decoded matched MU Protocol id $id dmsg $dmsg length $bit_length dispatch($nrDispatch/". AttrVal($name,'maxMuMsgRepeat', 4) . ")$rssiStr";
 					SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 					if ( $nrDispatch == AttrVal($name,"maxMuMsgRepeat", 4))
@@ -2566,6 +2569,7 @@ SIGNALduino_Parse_MC($$$$@)
 						}
 						SIGNALduno_Dispatch($hash,$rmsg,$dmsg,$rssi,$id);
 						$message_dispatched=1;
+						$hash->{LAST_Protocol_ID} = $id;
 					}
 				} else {
 					$res="undef" if (!defined($res));

--- a/UnitTest/tests/test_sub_SIGNALduino_dispatch-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_dispatch-definition.txt
@@ -1,0 +1,12 @@
+defmod test_sub_SIGNALduino_dispatch UnitTest dummyDuino ( 
+{ 
+ my $mock = Mock::Sub->new; 	
+ my $FHEM_Dispatch = $mock->mock("Dispatch");  	
+ my $rmsg="MS;P2=463;P3=-1957;P5=-3906;P6=-9157;D=26232523252525232323232323252323232323232325252523252325252323252325232525;CP=2;SP=6;R=75;";
+ my $dmsg="s5C080EB2B000";
+ SIGNALduno_Dispatch($targetHash, $rmsg, $dmsg,"-36.4","0.3");
+ is(($FHEM_Dispatch->called_with)[1], $dmsg, "Dispatch check dmsg" );
+ is(InternalVal($targetHash->{NAME},"LASTDMSG",""), $dmsg, "check Internal LASTDMSG" );
+ is(InternalVal($targetHash->{NAME},"LASTDMSGID",""), "0.3", "check Internal LASTDMSGID" );
+} 
+)


### PR DESCRIPTION
- added Internal LAST_Protocol_ID -> internal return last dispatched ID
https://github.com/RFD-FHEM/RFFHEM/issues/565

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [x] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- neues Internals LAST_Protocol_ID, welches ausgibt welche ID als letztes dispatcht wurde weil einige DMSG sind ohne Pxx preamble und somit nicht "sofort / schnell" zuordenbar
- es kann für User schneller abgelesen werden welche Nachricht als letztes dispatcht wurde
- https://github.com/RFD-FHEM/RFFHEM/issues/565

* **What is the current behavior?** (You can also link to an open issue here)
- Internals existiert nicht
