### PR TITLE
Fixes broken tests which use deprecated code

### DIFF
--- a/UnitTest/tests/test_1-definition.txt
+++ b/UnitTest/tests/test_1-definition.txt
@@ -1,4 +1,4 @@
-defmod test1 UnitTest dummyDuino 
+defmod test_1 UnitTest dummyDuino 
 (
  {
 	 my $rmsg="MS;P1=502;P2=-9212;P3=-1939;P4=-3669;D=1234;CP=1;SP=2;";

--- a/UnitTest/tests/test_3-definition.txt
+++ b/UnitTest/tests/test_3-definition.txt
@@ -1,4 +1,4 @@
-defmod test3 UnitTest dummyDuino 
+defmod test_3 UnitTest dummyDuino 
 (
  {
 	 my $mock;

--- a/UnitTest/tests/test_4-definition.txt
+++ b/UnitTest/tests/test_4-definition.txt
@@ -1,4 +1,4 @@
-defmod test4 UnitTest dummyDuino ( 
+defmod test_4 UnitTest dummyDuino ( 
 { 
 my $mock = Mock::Sub->new;
 $attr{$target}{eventlogging}=0;

--- a/UnitTest/tests/test_MS_2-definition.txt
+++ b/UnitTest/tests/test_MS_2-definition.txt
@@ -3,14 +3,15 @@ defmod test_MS_2 UnitTest dummyDuino (
 	my $mock = Mock::Sub->new;
 	my $SD_Dispatch = $mock->mock("SIGNALduno_Dispatch");
 	
-	my %ProtocolListTest =  SIGNALduino_LoadProtocolHash("$attr{global}{modpath}/FHEM/lib/test_loadprotohash-ok.pm");
-	my $local_ProtocolListSIGNALduino = SIGNALduino_getProtocolList();
-	%{$local_ProtocolListSIGNALduino} = ( %ProtocolListTest);
+    my %local_ProtocolListSIGNALduino =  SIGNALduino_LoadProtocolHash("$attr{global}{modpath}/FHEM/lib/test_loadprotohash-ok.pm");
+    my $ProtocolListSIGNALduino_REF = SIGNALduino_getProtocolList();
+    
+    %$ProtocolListSIGNALduino_REF = %local_ProtocolListSIGNALduino;
 
-	foreach my $pID (keys %$local_ProtocolListSIGNALduino)
+    foreach my $pID (keys %local_ProtocolListSIGNALduino)
 	{	
-		next if (!exists($local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}));
-    	foreach my $testData (values %$local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}) 
+		next if (!exists($local_ProtocolListSIGNALduino{$pID}{test_data}{$name}));
+    	foreach my $testData (values @{$local_ProtocolListSIGNALduino{$pID}{test_data}{$name}}) 
         {
           subtest "$testData->{desc}" => sub {
               SIGNALduino_IdList("sduino_IdList:$target",$pID);

--- a/UnitTest/tests/test_modulematch_1-definition.txt
+++ b/UnitTest/tests/test_modulematch_1-definition.txt
@@ -9,11 +9,11 @@ defmod test_modulematch_1 UnitTest dummyDuino (
 		is($ProtocolListTest{$id}{id},$id,"id $id exists");
 	}
 	my $local_ProtocolListSIGNALduino = SIGNALduino_getProtocolList();
-	foreach (keys %$local_ProtocolListSIGNALduino)
+	foreach (keys %{$local_ProtocolListSIGNALduino})
     {
         delete $local_ProtocolListSIGNALduino->{$_};
     }
-	%{$local_ProtocolListSIGNALduino} = ( %ProtocolListTest);
+    %$local_ProtocolListSIGNALduino = %ProtocolListTest;
 
 	
  

--- a/UnitTest/tests/test_mu_1-definition.txt
+++ b/UnitTest/tests/test_mu_1-definition.txt
@@ -1,5 +1,7 @@
 defmod test_mu_1 UnitTest dummyDuino (
  {
+	use warnings; 
+	use diagnostics;
   	my $mock = Mock::Sub->new;
 	my $SD_Dispatch = $mock->mock("SIGNALduno_Dispatch");
 	
@@ -10,7 +12,7 @@ defmod test_mu_1 UnitTest dummyDuino (
     foreach my $pID (keys %$local_ProtocolListSIGNALduino)
 	{	
 		next if (!exists($local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}));
-    	foreach my $testData (values %$local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}) 
+    	foreach my $testData (values $local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}) 
         {
           subtest "$testData->{desc}" => sub {
               SIGNALduino_IdList("sduino_IdList:$target",$pID);

--- a/UnitTest/tests/test_mu_1-definition.txt
+++ b/UnitTest/tests/test_mu_1-definition.txt
@@ -1,18 +1,16 @@
 defmod test_mu_1 UnitTest dummyDuino (
  {
-	use warnings; 
-	use diagnostics;
   	my $mock = Mock::Sub->new;
 	my $SD_Dispatch = $mock->mock("SIGNALduno_Dispatch");
 	
-    my %ProtocolListTest =  SIGNALduino_LoadProtocolHash("$attr{global}{modpath}/FHEM/lib/test_loadprotohash-ok.pm");
-	my $local_ProtocolListSIGNALduino = SIGNALduino_getProtocolList();
-	%{$local_ProtocolListSIGNALduino} = ( %ProtocolListTest);
-
-    foreach my $pID (keys %$local_ProtocolListSIGNALduino)
-	{	
-		next if (!exists($local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}));
-    	foreach my $testData (values $local_ProtocolListSIGNALduino->{$pID}{test_data}{$name}) 
+    my %local_ProtocolListSIGNALduino =  SIGNALduino_LoadProtocolHash("$attr{global}{modpath}/FHEM/lib/test_loadprotohash-ok.pm");
+    my $ProtocolListSIGNALduino_REF = SIGNALduino_getProtocolList();
+    
+    %$ProtocolListSIGNALduino_REF = %local_ProtocolListSIGNALduino;
+    foreach my $pID (keys %local_ProtocolListSIGNALduino)
+	{
+		next if (!exists($local_ProtocolListSIGNALduino{$pID}{test_data}{$name}));
+    	foreach my $testData (values @{$local_ProtocolListSIGNALduino{$pID}{test_data}{$name}}) 
         {
           subtest "$testData->{desc}" => sub {
               SIGNALduino_IdList("sduino_IdList:$target",$pID);
@@ -33,3 +31,4 @@ defmod test_mu_1 UnitTest dummyDuino (
 
  }
 );
+


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR will remove code that is deprecated starting at 5.22 
And it reanables skipped Tests: Test_1 and Test_3 

* **What is the current behavior?** (You can also link to an open issue here)


Code in tests doesn't run on Perl 5.22 or higher
Test1, test3 and test4 are not found by makefile regex

* **What is the new behavior (if this is a feature change)?**

Test1 is renamed to test_1
test3 is renamed to test_3
test4 is renamed to test_4

Code which uses hashrefs on hashes is changed to accesss hash on tests
Experimental code is removed from tests

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no


* **Other information**:

this only changes the unittests so that they are running without failures