### PR TITLE
Build Perl if needed to test whith most used versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 sudo: enabled
 language: perl
 perl:
-- '5.26'
-- '5.24'
-- "5.18"
+- '5.26@cover'
+- '5.24@cover'
+- '5.20@cover'
+- '5.14@cover'
+matrix:
+  allow_failures:
+    - perl: "5.14@cover"
+cache:
+   directories:
+      - $HOME/perl5
 env:
   global:
     secure: QZkNIahKdBIE/ANg04akx6MNgFItbLVSvGrR2By6rjHqrU9kllv862aVmcOjJw5/lcewEgRMgdK8ddhCKunW5HKpgW9CrkTi2GYVcmnJpw39ye7UnIIyOJM1N3YC+vWAaru+LJh8rHkXSfopKiiOjq9uTtfFCt+kngP7oIRKfPJ/7qdgKWvYpqKnqGoFoXghBWKe3V63xunILMkRVeTg+ogBOXbRy+3OU4WBIc4DsGdKOz+XkTecjLM9sdoyYLWUodLcmqwfCNGKWKwjVOaIe+859QtIoAEkclJtXunn6wYOeaumAJ+dILKZmOt4ORQxVYtVs+3W0eUl8+Z12xi6SGCenIQQGFHjxQgbjekXCiN56vf5LQUlxSEktjK67o9tq3+8VpgnPxqAgFOh4CvX4Ite3IT2+mPMegFOJavuyN/xOTuZgTe3sXDJzCfDBTQdBrb94ex/eZWZPn0M5Dkupiegh1CK6lJFVUwHpcJWb11SI2hzQRsGtPmlxDOfi48n23gVt7/bDeJS8rUlQoehF5fTVY1lMo4SZkB1Zs/ykm+NjPFg7h03j9E1msGFE/wQOZsN550GSxnpacZT9HandaxundiQHmVUfHHR54ieLxd3/xSTjqEpZcai21Oiq2ghmagGp8s+eRdNejMWLVWuHuWynFr72XU3LSXBW6YWyIc=
 git:
   depth: false
 before_install:
+ - eval $(curl https://travis-perl.github.io/init) --perl --always-upgrade-modules
+ - perl -V
  - git config --global user.email "travis@travis-ci.org"
  - git config --global user.name "Travis CI"
  - git config --global push.default simple
@@ -17,7 +26,7 @@ before_install:
  - wget -qO - http://debian.fhem.de/archive.key | sudo apt-key add -
  - echo "deb http://debian.fhem.de/nightly/ /" | sudo tee -a /etc/apt/sources.list
 install:
- - cpanm File::Find File::Basename Mock::Sub Test::More Test::Device::SerialPort Devel::Cover Devel::Cover::Report::Coveralls JSON Net::SSLeay --notest 
+ - cpanm List::Util File::Find File::Basename Mock::Sub Test::More Test::Device::SerialPort Devel::Cover Devel::Cover::Report::Coveralls  JSON Net::SSLeay --notest 
  - sudo apt-get update -qq
  - sudo apt-get install fhem -y
  - sudo chown travis -R /opt/fhem


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix with feature

* **What is the current behavior?** (You can also link to an open issue here)

Perl 5.18 is not any longer available in a precompiled version from travis ci.
Tests are currently failing because of this

* **What is the new behavior (if this is a feature change)?**

To prevent errors when travis removes support for a perl version, a perl helper (https://github.com/travis-perl/helpers) is used to use a precompiled version or compile a version if needed.
The used perl versions for testing are aligned to the most used from fhem statisics which are 5.26, 5.24, 5.20 and 5.14. 

5.14 tests hangs but is allowed to fail.
If this issue can't be fixed i'll remove it from supported version.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:
This PR just changed the way, how perl is installed for the unittests