### PR TITLE
00_SIGNALduino.pm - better LogOutput

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -872,7 +872,7 @@ SIGNALduino_Get($@)
 	my $hardware=AttrVal($name,"hardware",undef);
 	
 	my ($validHw) = $modules{$hash->{TYPE}}{AttrList} =~ /.*hardware:(.*?)\s/;  	
-	SIGNALduino_Log3 $name, 1, "$name: $validHw";
+	SIGNALduino_Log3 $name, 1, "$name: found availableFirmware for $validHw";
 	
 	if (!defined($hardware) || $validHw !~ /$hardware(?:,|$)/ )
   	{


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- better LogOutput if user push get availableFirmware

* **What is the current behavior?** (You can also link to an open issue here)
- without comment what happens
- nano_868Mhz: ESP_1M,ESP32,nano328,nanoCC1101,miniculCC1101,promini,radinoCC1101

* **What is the new behavior (if this is a feature change)?**
- nano_868Mhz: found availableFirmware for ESP_1M,ESP32,nano328,nanoCC1101,miniculCC1101,promini,radinoCC1101
