### PR TITLE
14_SD_Keeloq.pm - fixes

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,5 @@
+01.09.2019
+ 14_SD_Keeloq.pm: fix shade function
 31.08.2019
  14_SD_Keeloq.pm: fix group control 9-16  | added enhancement (shade for groups)
                   reduced repeats for shade after test | fix serial send syntax

--- a/FHEM/14_SD_Keeloq.pm
+++ b/FHEM/14_SD_Keeloq.pm
@@ -221,7 +221,7 @@ sub Attr(@) {
 					my $Channels = AttrVal($name, "Channels", "");
 					return "ERROR: you can use Channels = $attrValue only with defined attribut addGroups!" if ($attrValue == 0 && $addGroups eq "");
 					if ($Channels > $attrValue) {
-						foreach my $d (sort keys %{$hash->{READINGS}}) {
+						foreach my $d (keys %{$hash->{READINGS}}) {
 							if ($d =~ /^LastAction_Channel_(\d+)/) {
 								readingsDelete($hash, $d) if ($1 > $attrValue);
 							}

--- a/FHEM/14_SD_Keeloq.pm
+++ b/FHEM/14_SD_Keeloq.pm
@@ -20,13 +20,14 @@ use POSIX;
 use Data::Dumper qw (Dumper);
 
 my %models = (
-	"JaroLift" =>	{	Button => { "up"					=>	"1000",
-															"stop"				=>	"0100",	# new LearnVersion (2)
-															"down"				=>	"0010",
-															"learn"				=>	"0001",	# old LearnVersion
-															"shade"				=>	"0101", # 20x stop	(stop with 20x repeats) mod to 15 repeats after test | old 0101 | other user 0100 ?
-															"shade_learn"	=>	"",			# 4x stop		(stop 4x push)
-															"updown"			=>	"1010"	# new LearnVersion (1)
+	"JaroLift" =>	{	Button => { "up"					=>	"1000",	# button
+															"stop"				=>	"0100",	# button - for learn (LearnVersion new, step 2)
+															"down"				=>	"0010",	# button
+															"learn"				=>	"0001",	# function - old LearnVersion
+															"shade"				=>	"0101", # function - 20x stop	(stop with 20x repeats) mod to 15 repeats after test
+																												# manual - button Stop push 5 seconds (2012)
+															"shade_learn"	=>	"",			# function -  4x stop	(stop 4x push)
+															"updown"			=>	"1010"	# buttons together - for learn (LearnVersion new, step 1)
 														},
 									Channel => {	1		=>	"0000",
 																2		=>	"0001",
@@ -57,8 +58,8 @@ my %models = (
 																	},
 												Protocol 	=> "P88",
 												Typ				=> "remote"
-											},	
-	
+											},
+
 	"RP_S1_HS_RF11" => {	Button => {	"one"			=>	"1000",
 																		"two"			=>	"0010",
 																		"one+two"	=>	"1010"
@@ -165,16 +166,16 @@ sub Define() {
 	} else {
 		$model = "unknown";
 	};
-	
+
 	my $iodevice = $a[3] if($a[3]);
 
 	$modules{SD_Keeloq}{defptr}{$hash->{DEF}} = $hash;
 	my $ioname = $modules{SD_Keeloq}{defptr}{ioname} if (exists $modules{SD_Keeloq}{defptr}{ioname} && not $iodevice);
 	$iodevice = $ioname if not $iodevice;
-	
+
 	$attr{$name}{room}		= "SD_Keeloq" if ( not exists($attr{$name}{room}) );
 	$attr{$name}{model}		= $model if ( not exists($attr{$name}{model}) );
-	
+
 	AssignIoPort($hash, $iodevice);
 	return undef;
 }
@@ -216,18 +217,26 @@ sub Attr(@) {
 					$attr{$name}{ChannelNames} = $attrValue;
 				}
 
-				if ($attrName eq "Channels" && $attrValue == 0 && $addGroups eq "") {
-					return "ERROR: you can use Channels = $attrValue only with defined attribut addGroups!";
+				if ($attrName eq "Channels") {
+					my $Channels = AttrVal($name, "Channels", "");
+					return "ERROR: you can use Channels = $attrValue only with defined attribut addGroups!" if ($attrValue == 0 && $addGroups eq "");
+					if ($Channels > $attrValue) {
+						foreach my $d (sort keys %{$hash->{READINGS}}) {
+							if ($d =~ /^LastAction_Channel_(\d+)/) {
+								readingsDelete($hash, $d) if ($1 > $attrValue);
+							}
+						}
+					}
 				}
-				
+
 				if ($attrName eq "UI" && $attrValue eq "Einzeilig" && not exists $attr{$name}{Channels} && not exists $attr{$name}{ChannelFixed}) {
 					setReadingsVal($hash,"DDSelected",1,FmtDateTime(time()));
 				}
-				
+
 				if ($attrName eq "ChannelFixed"&& $attrValue > $attr{$name}{Channels}) {
 					return "ERROR: your $attrName attribut with value $attrValue is wrong!\nIt is no compatible with ".$attr{$name}{Channels}." channel option.";
 				}
-				
+
 				if ($attrName eq "Serial_send" && $attrValue !~ /^[0-9a-fA-F]{4}00/) {
 					return "ERROR: your $attrName attribut with value $attrValue is wrong!\nOnly support values with 00 at END!";
 				}
@@ -321,6 +330,7 @@ sub Set($$$@) {
 	my $ret;
 
 	my $cmd = $a[0];
+	my $cmd_org = $cmd;
 	my $cmd2 = $a[1];
 
 	### Typ JaroLift ###
@@ -434,7 +444,7 @@ sub Set($$$@) {
 			}
 
 			foreach my $i (1..$foreachCount) {
-				Log3 $name, 4, "$ioname: SD_Keeloq_Set - check, foreachCount=$foreachCount cmd=$cmd";
+				Log3 $name, 4, "$ioname: SD_Keeloq_Set - check, foreachCount=$foreachCount function=$cmd_org cmd=$cmd";
 				## LearnVersion new - part 1
 				if ($learning ne "old" && $cmd eq "learn" && $i == 1) {
 					$cmd = "updown";
@@ -454,7 +464,8 @@ sub Set($$$@) {
 				}
 
 				$button = $cmd;
-				$buttonbits = $models{$model}{Button}{$cmd};
+				$buttonbits = $models{$model}{Button}{$cmd} if ($cmd ne "shade");
+				$buttonbits = $models{$model}{Button}{stop} if ($cmd eq "shade");		# for status shade
 				my $learning_text = $learning eq "old" ? "send learn" : "send updown and additionally followed stop"; 
 				Log3 $name, 4, "$ioname: SD_Keeloq_Set - check, foreachLoop=$i LearnVersion=$learning ($learning_text)" if ((defined $cmd2 && $learning eq "old") || (defined $cmd2 && $learning eq "new"));
 
@@ -564,7 +575,7 @@ sub Set($$$@) {
 
 				### Zusammenführen
 				my $bits = reverse (sprintf("%032b", $encoded)).reverse($models{$model}{Channel}{$channel}).reverse($Serial_send).reverse($buttonbits).reverse($bit64to71);
-				
+
 				# special, command shade -> 20 repeats = 2,34 s | 15 repeats = 1,75s
 				# userreport: 12 repeats ok https://github.com/HomeAutoUser/SD_Keeloq__old_Jaro/issues/9#issuecomment-524176737
 				$Repeats = 15 if ($cmd eq "shade");
@@ -583,7 +594,7 @@ sub Set($$$@) {
 				Log3 $name, 5, "$ioname: SD_Keeloq_Set - Counter                   = $counter_send";
 				Log3 $name, 5, "$ioname: SD_Keeloq_Set - encoded (encrypt)         = ".sprintf("%032b", $encoded)."\n";
 
-				my $binsplit = SD_Keeloq_binsplit_JaroLift($bits);
+				my $binsplit = SD_Keeloq_binsplit_JaroLift($bits) if (AttrVal($name, "verbose", "3") eq "5");
 
 				Log3 $name, 5, "$ioname: SD_Keeloq_Set                                           encoded     <- | ->     decrypts";
 				Log3 $name, 5, "$ioname: SD_Keeloq_Set                       Grp 0-7 |digitS/N|      counter    | ch |          serial        | bt |Grp 8-15";
@@ -690,7 +701,7 @@ sub Parse($$) {
 	my $serialWithoutCh;
 	my $model = "unknown";
 	my $devicedef;
-	
+
 	if ($hlen == 17) {
 		$model = "unknown";
 		$serialWithoutCh = reverse (substr ($bitData , 32 , 28));						# 28bit serial
@@ -774,7 +785,7 @@ sub Parse($$) {
 		($bit8to15) = @_ = ( reverse (substr ($bitData , 8 , 8)) , "encrypted" )[$encrypted];			# without MasterMSB | MasterLSB encrypted
 		$bit64to71 = reverse (substr ($bitData , 64 , 8));
 
-		$binsplit = SD_Keeloq_binsplit_JaroLift($bitData);
+		$binsplit = SD_Keeloq_binsplit_JaroLift($bitData) if (AttrVal($name, "verbose", "3") eq "5");
 
 		Log3 $name, 5, "$ioname: SD_Keeloq_Parse - typ = $model";
 		Log3 $name, 5, "$ioname: SD_Keeloq_Parse                                 encoded     <- | ->     decrypts";
@@ -966,7 +977,7 @@ sub Parse($$) {
 	Log3 $name, 5, "$ioname: SD_Keeloq_Parse - user_modus                           = $modus";
 	Log3 $name, 5, "$ioname: SD_Keeloq_Parse - user_info                            = $info";
 	Log3 $name, 5, "######## DEBUG END ########\n";
-	
+
 	$VLOW = $VLOW eq "0" ? "ok" : "low" if (defined $VLOW);		# only chip HCS301 - RP_S1_HS_RF11 | Roto | Waeco_MA650_TX
 	$RPT = $RPT eq "0" ? "no" : "yes" if (defined $RPT);			# only chip HCS301 - RP_S1_HS_RF11 | Roto | Waeco_MA650_TX
 
@@ -1304,7 +1315,7 @@ sub SD_Keeloq_attr2htmlButtons($$$$$) {
 	<b><i>After entering the correct key, you will receive all states and the sending or controlling is possible!<br>
 	An anchoring of the keys in the module is NOT included and everyone has to manage it himself.</i></b><br>
 	- KeeLoq is a registered trademark of Microchip Technology Inc.-<br><br>
-	
+
 	<u>The following devices are supported:</u><br>
 	<ul> - JaroLift radio wall transmitter (example: TDRC 16W / TDRCT 04W)&nbsp;&nbsp;&nbsp;<small>(model: JaroLift | protocol 87)</small><br></ul>
 	<ul> - RADEMACHER remote with two button&nbsp;&nbsp;&nbsp;<small>(model: RP_S1_HS_RF11 | protocol 88)&nbsp;&nbsp;[HCS301 chip]</small><br></ul>
@@ -1468,7 +1479,7 @@ sub SD_Keeloq_attr2htmlButtons($$$$$) {
 	<b><i>Nach Eingabe der richtigen Schl&uuml;ssel erh&auml;lt man alle Zust&auml;nde und das Senden bzw. steuern ist m&ouml;glich!<br>
 	Eine Verankerung der Schl&uuml;ssel im Modul ist NICHT enthalten und jeder muss diese selbst verwalten.</i></b><br>
 	- KeeLoq is a registered trademark of Microchip Technology Inc.-<br><br>
-	
+
 	<u>Es werden bisher folgende Ger&auml;te unterst&uuml;tzt:</u><br>
 	<ul> - JaroLift Funkwandsender (Bsp: TDRC 16W / TDRCT 04W)&nbsp;&nbsp;&nbsp;<small>(Modulmodel: JaroLift | Protokoll 87)</small><br></ul>
 	<ul> - RADEMACHER Fernbedienung mit 2 Tasten&nbsp;&nbsp;&nbsp;<small>(Modulmodel: RP_S1_HS_RF11 | Protokoll 88)&nbsp;&nbsp;[HCS301 chip]</small><br></ul>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [x] commandref has been added / updated (needed for bug fixes / features)
- [X] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fix, feature

* **What is the current behavior?** (You can also link to an open issue here)
- shade function not work
- superfluous readings are always retained

* **What is the new behavior (if this is a feature change)?**
- added more information to JaroLift buttons
- fix https://github.com/RFD-FHEM/RFFHEM/issues/640 Call SD_Keeloq_binsplit_JaroLift only if verbose >=5
- fix shade function https://github.com/HomeAutoUser/SD_Keeloq__old_Jaro/issues/9
- deleting superfluous readings when channels are being downsized https://github.com/HomeAutoUser/SD_Keeloq__old_Jaro/issues/17