### PR TITLE
Add unitetests for get raw

### DIFF
--- a/UnitTest/tests/test_get_raw-definition.txt
+++ b/UnitTest/tests/test_get_raw-definition.txt
@@ -39,7 +39,7 @@ defmod test_get_raw UnitTest dummyDuino
 		{
 			is( ($SD_Parse->called_with)[3], "\002".$rawArg."\003" , 'check if SIGNALduino_Parse was called' ) || diag(explain $SD_Parse);
 		} 
-		$mock->unmock;
+		$SD_Parse->unmock;
 	}; 
 	
 	subtest 'Test get raw file=something.txt;' => sub {
@@ -48,6 +48,7 @@ defmod test_get_raw UnitTest dummyDuino
 		my $rawArg="file=something.txt";
 		my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
 		like($ret,qr/Could not open file.*/,"Check file not opened");
+		
 		TODO : {
 			local $TODO="file must be specified";
 			my $rawArg="file=./fhem_ut.txt";

--- a/UnitTest/tests/test_get_raw-definition.txt
+++ b/UnitTest/tests/test_get_raw-definition.txt
@@ -1,8 +1,7 @@
 defmod test_get_raw UnitTest dummyDuino 
 (
  {
-
-	subtest 'Test get gaw intertechno switch' => sub {
+	subtest 'Test get raw intertechno switch' => sub {
 		plan tests => 2;
 		CommandAttr(undef,"$target dummy 0");
 		my $rawArg="is10101010101010101010101010101010";
@@ -12,6 +11,50 @@ defmod test_get_raw UnitTest dummyDuino
 		$rawArg="is10101010101010101";
 		$ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
 		is($ret,undef,"check return is undef");
+		CommandAttr(undef,"$target dummy 1");
+		
 	}; 
+
+	subtest 'Test get raw questionmark' => sub {
+		plan tests => 6;
+		CommandAttr(undef,"$target dummy 1");
+		my $rawArg="?";
+		my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+		like($ret,qr/^dummy get raw.*/,"check return contains help");
+		like($ret,qr/raw message.*/,"check return contains raw message");
+		like($ret,qr/dispatch message.*/,"check return contains dispatch message");
+		like($ret,qr/version=.*/,"check return version=");
+		like($ret,qr/regexp=.*/,"check return regexp=");
+		like($ret,qr/file=.*/,"check return file=");
+	}; 
+	
+	subtest 'Test get raw MS;P1=309;' => sub {
+		plan tests => 1;
+		my $mock = Mock::Sub->new;
+	 	my $SD_Parse = $mock->mock('SIGNALduino_Parse');
+		my $rawArg="MS;P1=309;";
+		my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+		
+		if ($SD_Parse->called)
+		{
+			is( ($SD_Parse->called_with)[3], "\002".$rawArg."\003" , 'check if SIGNALduino_Parse was called' ) || diag(explain $SD_Parse);
+		} 
+		$mock->unmock;
+	}; 
+	
+	subtest 'Test get raw file=something.txt;' => sub {
+		plan tests => 2;
+
+		my $rawArg="file=something.txt";
+		my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+		like($ret,qr/Could not open file.*/,"Check file not opened");
+		TODO : {
+			local $TODO="file must be specified";
+			my $rawArg="file=./fhem_ut.txt";
+			my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+			like($ret,qr/raw Nachrichten eingelesen$/,"Check file not opened");
+		}
+	}; 
+	
 }
 )

--- a/UnitTest/tests/test_get_raw-definition.txt
+++ b/UnitTest/tests/test_get_raw-definition.txt
@@ -1,0 +1,17 @@
+defmod test_get_raw UnitTest dummyDuino 
+(
+ {
+
+	subtest 'Test get gaw intertechno switch' => sub {
+		plan tests => 2;
+		CommandAttr(undef,"$target dummy 0");
+		my $rawArg="is10101010101010101010101010101010";
+		my $ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+		like($ret,qr/$rawArg$/,"check return contains correct arg");
+		
+		$rawArg="is10101010101010101";
+		$ret=SIGNALduino_Get($targetHash, $target, "raw", $rawArg);
+		is($ret,undef,"check return is undef");
+	}; 
+}
+)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Unittests

* **What is the current behavior?** (You can also link to an open issue here)

There are no unittests which verifies different get raw .. options

* **What is the new behavior (if this is a feature change)?**

The following commands are checked
get raw ?
get raw is...
get raw MS;..

get raw file= 
Option which opens a existing file doesn't work. This has to be done somehow later.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


No

* **Other information**:
