### PR TITLE
Radino flash with DEF /dev/serial/by-id/

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,4 @@
+26.10.2019
 22.10.2019
   00_SIGNALduino.pm: added specify arduino hardware type (ESP8266,ESP8266cc1101)
 	 - attribute ESP1_M is deleted

--- a/CHANGED
+++ b/CHANGED
@@ -1,4 +1,5 @@
 26.10.2019
+  00_SIGNALduino.pm: allows flash radino with DEF /dev/serial/by-id/
 22.10.2019
   00_SIGNALduino.pm: added specify arduino hardware type (ESP8266,ESP8266cc1101)
 	 - attribute ESP1_M is deleted

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -449,14 +449,6 @@ SIGNALduino_flash($) {
 	local $SIG{CHLD} = 'DEFAULT';
 	delete($hash->{FLASH_RESULT}) if (exists($hash->{FLASH_RESULT}));
 
-	my $hardware=AttrVal($name,"hardware","");
-	if ($hardware eq "radinoCC1101") {
-		# Normalbetrieb:    /dev/serial/by-id/usb-Unknown_radino_CC1101-if00@57600
-		# Bootloader aktiv: /dev/serial/by-id/usb-In-Circuit_radino_CC1101-if00@57600
-		$hash->{helper}{avrdudecmd} =~ s/usb-Unknown_radino/usb-In-Circuit_radino/g;
-		$hash->{logMethod}->($name ,3, "$name: changed avrdude flashcommand: " . $hash->{helper}{avrdudecmd});
-	}
-
 	qx($hash->{helper}{avrdudecmd});
 	if ($? != 0 )
 	{
@@ -657,8 +649,9 @@ SIGNALduino_Set($@)
 				$hash->{helper}{stty_pid}=$pid;
 		  		$hash->{helper}{stty_output} = join(" ",@outlines).join(" ",@errlines);
 			}
+			$port =~ s/usb-Unknown_radino/usb-In-Circuit_radino/g;
+			$hash->{logMethod}->($name ,3, "$name: changed usb port to \"$port\" for avrdude flashcommand compatible with radino");
 		}
-		
 		$hash->{helper}{avrdudecmd} = $flashCommand;
 		$hash->{helper}{avrdudecmd}=~ s/\Q[PORT]\E/$port/g;
 		$hash->{helper}{avrdudecmd} =~ s/\Q[BAUDRATE]\E/$baudrate/g;

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -448,6 +448,15 @@ SIGNALduino_flash($) {
     $hash->{helper}{avrdudecmd} =~ s/\Q[LOGFILE]\E/$logFile/g;
 	local $SIG{CHLD} = 'DEFAULT';
 	delete($hash->{FLASH_RESULT}) if (exists($hash->{FLASH_RESULT}));
+
+	my $hardware=AttrVal($name,"hardware","");
+	if ($hardware eq "radinoCC1101") {
+		# Normalbetrieb:    /dev/serial/by-id/usb-Unknown_radino_CC1101-if00@57600
+		# Bootloader aktiv: /dev/serial/by-id/usb-In-Circuit_radino_CC1101-if00@57600
+		$hash->{helper}{avrdudecmd} =~ s/usb-Unknown_radino/usb-In-Circuit_radino/g;
+		$hash->{logMethod}->($name ,3, "$name: changed avrdude flashcommand: " . $hash->{helper}{avrdudecmd});
+	}
+
 	qx($hash->{helper}{avrdudecmd});
 	if ($? != 0 )
 	{

--- a/UnitTest/tests/test_firmware_flash_1-definition.txt
+++ b/UnitTest/tests/test_firmware_flash_1-definition.txt
@@ -88,8 +88,6 @@ defmod test_firmware_flash_1 UnitTest dummyDuino
 		$OpenDev->unmock;
 		CommandAttr(undef,"global logdir $logdir");
 		$targetHash->{helper}{avrdudecmd} = $preparedavrdudecmd;	
-	
-		
 	}; 
 
 	
@@ -112,23 +110,31 @@ defmod test_firmware_flash_1 UnitTest dummyDuino
 
 
 	subtest 'set flash avrdude installed (radinoCC1101)' => sub {
-		plan tests => 7;
+		plan tests => 9;
 		$attr{$target}{hardware} ="radinoCC1101";
 		my $IntTimer = $mock->mock('main::InternalTimer');
 		
 		$ENV{'PATH'}="/opt/fhem/contrib";
 		my $ret = SIGNALduino_Set($targetHash, $target, "flash" ,"./fhem/test.hex");
-		$ENV{'PATH'}=$path;
 		is($ret, undef, "check return value with avrdude installed");		
 		is($IntTimer->called_count, 1, "check if InternalTimer is called once");		
 		my @called_args=$IntTimer->called_with;
-		$IntTimer->unmock;
 
 		like($targetHash->{helper}{stty_output},'/^open3: exec of stty -F none ospeed 1200 ispeed 1200 failed/m',"check if stty was called");
 		ok($called_args[0] > gettimeofday(), "check arg 1 InternalTimer is called ");		
 		is($called_args[1], "SIGNALduino_flash", "check arg 2 InternalTimer is called ");		
 		is($called_args[2], $target, "check arg 3 InternalTimer is called ");		
 		is($targetHash->{helper}{avrdudecmd},'avrdude -c avr109 -b 57600 -P none -p atmega32u4 -vv -D -U flash:w:./fhem/test.hex 2>[LOGFILE]',"check avrdude cmd");
+		
+		$targetHash->{DeviceName}='/dev/serial/by-id/usb-Unknown_radino_CC1101-if00@57600';
+		$ret = SIGNALduino_Set($targetHash, $target, "flash" ,"./fhem/test.hex");
+		$ENV{'PATH'}=$path;
+		is($ret, undef, "check SIGNALduino_Set return value");		
+		
+		is($targetHash->{helper}{avrdudecmd},'avrdude -c avr109 -b 57600 -P /dev/serial/by-id/usb-In-Circuit_radino_CC1101-if00 -p atmega32u4 -vv -D -U flash:w:./fhem/test.hex 2>[LOGFILE]',"check avrdude cmd");
+		$targetHash->{DeviceName}='none';
+		$IntTimer->unmock;
+		
 	}; 
 	
 	subtest 'set flash avrdude installed (esp8266,esp32)' => sub {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [x] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
Radino flash only possible with DEF /dev/ttyACM

* **What is the new behavior (if this is a feature change)?**
Radino allows flash with DEF /dev/serial/by-id/

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
