### PR TITLE
Fix line ending to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.

--- a/UnitTest/tests/test_firmware_flash_1-definition.txt
+++ b/UnitTest/tests/test_firmware_flash_1-definition.txt
@@ -76,7 +76,7 @@ defmod test_firmware_flash_1 UnitTest dummyDuino
 		$targetHash->{helper}{avrdudecmd} = $preparedavrdudecmd;	
 
 		CommandAttr(undef,"global logdir ./jiddsidio/log/");
-		my $ret = SIGNALduino_flash($target);
+		$ret = SIGNALduino_flash($target);
 		
 		is($ret, "WARNING: avrdude created no log file", "check return value");		
 		is($targetHash->{FLASH_RESULT},$ret, "check internal value");		


### PR DESCRIPTION
Add lf as standard line ending

UnitTest/tests/test_firmware_flash_1-definition.txt

Removed redeclaration of variable to avoid warning

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** bugfix

* **What is the current behavior?** (You can also link to an open issue here)

Lineending is not specifyed as default. For avrdude linenending is controlled by user preferences

* **What is the new behavior (if this is a feature change)?**

Linenending is specified as default. For avrdude linenending is now lf and not anymore user defined

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
