### PR TITLE
Flash nano with new bootloader optiboot

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,5 @@
+28.10.2019
+  00_SIGNALduino.pm: allows flash nano328 and nanoCC1101 with new bootloader optiboot
 26.10.2019
   00_SIGNALduino.pm: allows flash radino with DEF /dev/serial/by-id/
 22.10.2019

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -451,13 +451,6 @@ SIGNALduino_flash($) {
 
 	qx($hash->{helper}{avrdudecmd});
 
-	my $hardware=AttrVal($name,"hardware","");
-	if ($? != 0 && ($hardware eq "nano328" || $hardware eq "nanoCC1101"))
-	{
-		$hash->{logMethod}->($name ,3, "$name: ERROR: avrdude exited with error, try with 115200 baud");
-		$hash->{helper}{avrdudecmd} =~ s/57600/115200/g;	# new bootloader optiboot used 115200
-		qx($hash->{helper}{avrdudecmd});
-	}
 
 	if ($? != 0 )
 	{
@@ -663,8 +656,13 @@ SIGNALduino_Set($@)
 		}
 		$hash->{helper}{avrdudecmd} = $flashCommand;
 		$hash->{helper}{avrdudecmd}=~ s/\Q[PORT]\E/$port/g;
-		$hash->{helper}{avrdudecmd} =~ s/\Q[BAUDRATE]\E/$baudrate/g;
 		$hash->{helper}{avrdudecmd} =~ s/\Q[HEXFILE]\E/$hexFile/g;
+		if ($hardware =~ "^nano" && $^O eq 'linux') {
+			$hash->{helper}{avrdudecmd} = $hash->{helper}{avrdudecmd}." || ". $hash->{helper}{avrdudecmd}; 
+			$hash->{helper}{avrdudecmd} =~ s/\Q[BAUDRATE]\E/$baudrate/;
+			$baudrate=115200;
+		}	
+		$hash->{helper}{avrdudecmd} =~ s/\Q[BAUDRATE]\E/$baudrate/;
 		$log .= "command: $hash->{helper}{avrdudecmd}\n\n";
 		InternalTimer(gettimeofday() + 1,"SIGNALduino_flash",$name);
 	 	$hash->{helper}{avrdudelogs} = $log;

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -31,7 +31,7 @@ use lib::SD_Protocols;
 
 
 use constant {
-	SDUINO_VERSION            => "v3.4.1_dev_26.10",
+	SDUINO_VERSION            => "v3.4.1_dev_28.10",
 	SDUINO_INIT_WAIT_XQ       => 1.5,       # wait disable device
 	SDUINO_INIT_WAIT          => 2,
 	SDUINO_INIT_MAXRETRY      => 3,
@@ -450,6 +450,15 @@ SIGNALduino_flash($) {
 	delete($hash->{FLASH_RESULT}) if (exists($hash->{FLASH_RESULT}));
 
 	qx($hash->{helper}{avrdudecmd});
+
+	my $hardware=AttrVal($name,"hardware","");
+	if ($? != 0 && ($hardware eq "nano328" || $hardware eq "nanoCC1101"))
+	{
+		$hash->{logMethod}->($name ,3, "$name: ERROR: avrdude exited with error, try with 115200 baud");
+		$hash->{helper}{avrdudecmd} =~ s/57600/115200/g;	# new bootloader optiboot used 115200
+		qx($hash->{helper}{avrdudecmd});
+	}
+
 	if ($? != 0 )
 	{
 		readingsSingleUpdate($hash,"state","FIRMWARE UPDATE with error",1);    # processed in tests

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -658,6 +658,7 @@ SIGNALduino_Set($@)
 		$hash->{helper}{avrdudecmd}=~ s/\Q[PORT]\E/$port/g;
 		$hash->{helper}{avrdudecmd} =~ s/\Q[HEXFILE]\E/$hexFile/g;
 		if ($hardware =~ "^nano" && $^O eq 'linux') {
+			$hash->{logMethod}->($name ,5, "$name: try additional flash with baudrate 115200 for optiboot");
 			$hash->{helper}{avrdudecmd} = $hash->{helper}{avrdudecmd}." || ". $hash->{helper}{avrdudecmd}; 
 			$hash->{helper}{avrdudecmd} =~ s/\Q[BAUDRATE]\E/$baudrate/;
 			$baudrate=115200;

--- a/UnitTest/tests/test_firmware_flash_1-definition.txt
+++ b/UnitTest/tests/test_firmware_flash_1-definition.txt
@@ -70,7 +70,7 @@ defmod test_firmware_flash_1 UnitTest dummyDuino
 		is($targetHash->{helper}{stty_pid}, undef, "check stty_pid value");		
 		
 		is(ReadingsVal($target,"state",""),"FIRMWARE UPDATE with error","check reading state");
-		is($targetHash->{helper}{avrdudecmd},'avrdude -c arduino -b 57600 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./log/SIGNALduino-Flash.log',"check avrdude cmd");
+		is($targetHash->{helper}{avrdudecmd},'avrdude -c arduino -b 57600 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./log/SIGNALduino-Flash.log || avrdude -c arduino -b 115200 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./log/SIGNALduino-Flash.log',"check avrdude cmd");
 		is($OpenDev->called_count, 1, "check if DevIO_OpenDev is called once");		
 
 		$targetHash->{helper}{avrdudecmd} = $preparedavrdudecmd;	
@@ -83,7 +83,7 @@ defmod test_firmware_flash_1 UnitTest dummyDuino
 		is($targetHash->{helper}{stty_pid}, undef, "check stty_pid value");		
 		
 		is(ReadingsVal($target,"state",""),"FIRMWARE UPDATE with error","check reading state");
-		is($targetHash->{helper}{avrdudecmd},'avrdude -c arduino -b 57600 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./jiddsidio/log/SIGNALduino-Flash.log',"check avrdude cmd");
+		is($targetHash->{helper}{avrdudecmd},'avrdude -c arduino -b 57600 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./jiddsidio/log/SIGNALduino-Flash.log || avrdude -c arduino -b 115200 -P none -p atmega328p -vv -U flash:w:./fhem/test.hex 2>./jiddsidio/log/SIGNALduino-Flash.log',"check avrdude cmd");
 		is($OpenDev->called_count, 2, "check if DevIO_OpenDev is called once");		
 		$OpenDev->unmock;
 		CommandAttr(undef,"global logdir $logdir");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [x] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
Error during firmware update of an Arduino Nano with new bootloader OptiBoot.
https://github.com/RFD-FHEM/RFFHEM/issues/225

* **What is the new behavior (if this is a feature change)?**
Allows flash nano328 and nanoCC1101 with new bootloader optiboot by changing the interface speed from 57600 to 115200.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
