### PR TITLE
Added unittest for sub SIGNALDuino_StartInit

### DIFF
--- a/UnitTest/tests/test_sub_StartInit-definition.txt
+++ b/UnitTest/tests/test_sub_StartInit-definition.txt
@@ -1,0 +1,44 @@
+defmod test_sub_StartInit UnitTest dummyDuino ( 
+{ 
+	subtest 'Test with initretry=1' => sub {
+		plan tests => 4;
+		
+		my $mock = Mock::Sub->new;
+	 	my $SD_SimpleWrite = $mock->mock('SIGNALduino_SimpleWrite');
+		$targetHash->{initretry} = 1;
+		
+		my $ret=SIGNALduino_StartInit($targetHash);
+		is($SD_SimpleWrite->called,1,"SIGNALduino_SimpleWrite called");
+	    my @called_args = $SD_SimpleWrite->called_with;
+	    is( $called_args[1], "V", "SIGNALduino_SimpleWrite called with V" );
+		is($targetHash->{getcmd}->{cmd},"version","getcmd is version");
+		is($targetHash->{DevState},"waitInit","check DevState");
+		
+		$SD_SimpleWrite->unmock;
+	}; 
+
+	subtest 'Test with initretry=3' => sub {
+		plan tests => 5;
+		
+		my $mock = Mock::Sub->new;
+	 	my $SD_ResetDevice = $mock->mock('SIGNALduino_ResetDevice');
+		$targetHash->{initretry} = 3;
+		
+		is($targetHash->{initResetFlag},undef,"check initResetFlag before beginning");
+		my $ret=SIGNALduino_StartInit($targetHash);
+		is($SD_ResetDevice->called,1,"SIGNALduino_ResetDevice called");
+		is($targetHash->{DevState},"INACTIVE","check DevState");
+		is($targetHash->{initResetFlag},1,"check initResetFlag");
+		$SD_ResetDevice->unmock;
+		
+		my $SD_CloseDevice = $mock->mock('SIGNALduino_CloseDevice');
+		my $ret=SIGNALduino_StartInit($targetHash);
+		is($SD_CloseDevice->called,1,"SIGNALduino_CloseDevice called");
+		$SD_CloseDevice->unmock;
+		
+		
+	}; 
+
+
+} 
+)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** 

Unittest



* **What is the current behavior?** (You can also link to an open issue here)

Sub SIGNALDuino_StartInit is not covered by unittests

* **What is the new behavior (if this is a feature change)?**

Sub SIGNALDuino_StartInit is covered by unittests


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
