### PR TITLE
fix reset for dummy - #755

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -31,7 +31,7 @@ use lib::SD_Protocols;
 
 
 use constant {
-	SDUINO_VERSION            => "v3.4.2_dev_28.12",
+	SDUINO_VERSION            => "v3.4.2_dev_02.01",
 	SDUINO_INIT_WAIT_XQ       => 1.5,       # wait disable device
 	SDUINO_INIT_WAIT          => 2,
 	SDUINO_INIT_MAXRETRY      => 3,
@@ -1007,7 +1007,7 @@ sub SIGNALduino_ResetDevice($) {
 	my $hash = shift;
 	my $name = $hash->{NAME};
 
-	if (InternalVal($name,"DeviceName","none") eq "none") { # for dummy device
+	if (IsDummy($name)) { # for dummy device
 		$hash->{DevState} = "initialized";
 		readingsSingleUpdate($hash, "state", "opened", 1);
 		return;

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -1007,15 +1007,16 @@ sub SIGNALduino_ResetDevice($) {
 	my $hash = shift;
 	my $name = $hash->{NAME};
 
-	if (IsDummy($name)) { # for dummy device
-		$hash->{DevState} = "initialized";
-		readingsSingleUpdate($hash, "state", "opened", 1);
-		return;
-	}
-
 	if (!defined($hash->{helper}{resetInProgress})) {
 		my $hardware = AttrVal($name,"hardware","");
 		$hash->{logMethod}->($name, 3, "$name: ResetDevice, $hardware"); 
+
+		if (IsDummy($name)) { # for dummy device
+			$hash->{DevState} = "initialized";
+			readingsSingleUpdate($hash, "state", "opened", 1);
+			return undef;
+		}
+
 		DevIo_CloseDev($hash);
 	 	if ($hardware eq "radinoCC1101" && $^O eq 'linux') {
 			# The reset is triggered when the Micro's virtual (CDC) serial / COM port is opened at 1200 baud and then closed.

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -1006,8 +1006,14 @@ sub SIGNALduino_parseResponse($$$) {
 sub SIGNALduino_ResetDevice($) {
 	my $hash = shift;
 	my $name = $hash->{NAME};
-	if (!defined($hash->{helper}{resetInProgress}))
-	{
+
+	if (InternalVal($name,"DeviceName","none") eq "none") { # for dummy device
+		$hash->{DevState} = "initialized";
+		readingsSingleUpdate($hash, "state", "opened", 1);
+		return;
+	}
+
+	if (!defined($hash->{helper}{resetInProgress})) {
 		my $hardware = AttrVal($name,"hardware","");
 		$hash->{logMethod}->($name, 3, "$name: ResetDevice, $hardware"); 
 		DevIo_CloseDev($hash);

--- a/UnitTest/tests/test_reset_1-definition.txt
+++ b/UnitTest/tests/test_reset_1-definition.txt
@@ -12,8 +12,9 @@ defmod test_reset_1 UnitTest dummyDuino
 	}	
 	
 	subtest 'reset without hardware parameter set' => sub {
-		plan tests => 2;
+		plan tests => 3;
 		$attr{$target}{dummy} = 0;
+		is (AttrVal($target, "dummy", 0),0,"check attrib dummy is 0");		
 		$attr{$target}{hardware} = "";
 		my $ret = SIGNALduino_Set($targetHash, $target, "reset" ,"");
 		is ($SD_connect->called_count,1,"check if SIGNALduino_Connect is called once");

--- a/UnitTest/tests/test_reset_1-definition.txt
+++ b/UnitTest/tests/test_reset_1-definition.txt
@@ -13,6 +13,7 @@ defmod test_reset_1 UnitTest dummyDuino
 	
 	subtest 'reset without hardware parameter set' => sub {
 		plan tests => 2;
+		$attr{$target}{dummy} = 0;
 		$attr{$target}{hardware} = "";
 		my $ret = SIGNALduino_Set($targetHash, $target, "reset" ,"");
 		is ($SD_connect->called_count,1,"check if SIGNALduino_Connect is called once");
@@ -65,9 +66,18 @@ defmod test_reset_1 UnitTest dummyDuino
 		$IntTimer->unmock;
 		
 		is ($targetHash->{helper}{resetInProgress},undef,"check reset in progress flag deleted");
-	}; 
-    CommandDefMod(undef,"$target $targetHash->{TYPE} $targetHash->{DEF}");
+	};
 
+	subtest 'reset for dummy device' => sub {
+		plan tests => 3;
+		$attr{$target}{dummy} = 1;
+		is (AttrVal($target, "dummy", 0),1,"check dummy attrib dummy is 1");
+		is (ReadingsVal($target,"state",""),"disconnected","check dummy state disconnected");
+		
+		SIGNALduino_ResetDevice($targetHash);
+		is (ReadingsVal($target,"state",""),"opened","check dummy state opened");
+	};
 
+   CommandDefMod(undef,"$target $targetHash->{TYPE} $targetHash->{DEF}");
 }
 )


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
- if dummy set closed, command reset without function

* **What is the new behavior (if this is a feature change)?**
- added check for dummy, now dummy reset with command reset if closed  https://github.com/RFD-FHEM/RFFHEM/issues/755

