### PR TITLE
Update 00_SIGNALduino.pm - rename Internals

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -602,7 +602,7 @@ sub SIGNALduino_Set($$@) {
   
  	return "\"set SIGNALduino\" needs at least one parameter" if(@a < 1);
 
-	if (!InternalVal($name,"hasCC1101",0) && $a[0] =~ /^cc1101/) {
+	if (!InternalVal($name,"CC1101_Available",0) && $a[0] =~ /^cc1101/) {
 		return "This command is only available with a cc1101 receiver";
 	}
 	if (!exists($sets{$a[0]})) {
@@ -626,7 +626,7 @@ sub SIGNALduino_Set_FhemWebList {
 		($_ ne "?" && 
 			(
 				( IsDummy($hash->{NAME}) && $_ =~ m/^(?:close|reset)/ ) || 
-				( InternalVal($hash->{NAME},"hasCC1101",0) || (!InternalVal($hash->{NAME},"hasCC1101",0) && $_ !~ /^cc/)) &&
+				( InternalVal($hash->{NAME},"CC1101_Available",0) || (!InternalVal($hash->{NAME},"CC1101_Available",0) && $_ !~ /^cc/)) &&
 				( !IsDummy($hash->{NAME}) && (defined(DevIo_IsOpen($hash)) || $_ =~ m/^(?:flash|reset)/)  ) 
 			)
 		)	 
@@ -733,10 +733,10 @@ sub SIGNALduino_Set_sendMsg {
 
 	$repeats=1 if (!defined($repeats));
 
-	if (exists($ProtocolListSIGNALduino{$protocol}{frequency}) && InternalVal($hash->{NAME},"hasCC1101",0) && !defined($frequency)) {
+	if (exists($ProtocolListSIGNALduino{$protocol}{frequency}) && InternalVal($hash->{NAME},"CC1101_Available",0) && !defined($frequency)) {
 		$frequency = $ProtocolListSIGNALduino{$protocol}{frequency};
 	}
-	if (defined($frequency) && InternalVal($hash->{NAME},"hasCC1101",0)) {
+	if (defined($frequency) && InternalVal($hash->{NAME},"CC1101_Available",0)) {
 		$frequency="F=$frequency;";
 	} else {
 		$frequency="";
@@ -880,7 +880,7 @@ sub SIGNALduino_Get($@) {
 
  	return "\"get SIGNALduino\" needs at least one parameter" if(@a < 1);
 
-	if (!InternalVal($name,"hasCC1101",0) && $a[0] =~ /^cc/) {
+	if (!InternalVal($name,"CC1101_Available",0) && $a[0] =~ /^cc/) {
 		return "This command is only available with a cc1101 receiver";
 	}
 	if (!exists($gets{$a[0]})) {
@@ -927,7 +927,7 @@ sub SIGNALduino_Get_FhemWebList {
 		($_ ne "?" &&
 			( 
 				(IsDummy($hash->{NAME}) && $_ =~ m/^(?:availableFirmware|raw)/) || 
-				( InternalVal($hash->{NAME},"hasCC1101",0) || (!InternalVal($hash->{NAME},"hasCC1101",0) && $_ !~ /^cc/)) &&  
+				( InternalVal($hash->{NAME},"CC1101_Available",0) || (!InternalVal($hash->{NAME},"CC1101_Available",0) && $_ !~ /^cc/)) &&  
 				( !IsDummy($hash->{NAME}) && (defined(DevIo_IsOpen($hash))  ||  $_ =~ m/^(?:availableFirmware|raw)/  )) 
 			) 
 		) 
@@ -1312,7 +1312,7 @@ sub SIGNALduino_CheckVersionResp
 		$hash->{keepalive}{ok}    = 0;
 		$hash->{keepalive}{retry} = 0;
 		InternalTimer(gettimeofday() + SDUINO_KEEPALIVE_TIMEOUT, "SIGNALduino_KeepAlive", $hash, 0);
-	 	$hash->{hasCC1101} = 1  if ($hash->{version} =~ m/cc1101/);
+	 	$hash->{CC1101_Available} = 1  if ($hash->{version} =~ m/cc1101/);
 	 	$msg = $hash->{version};
 	}
 	return ($msg,undef);
@@ -1355,7 +1355,7 @@ sub SIGNALduino_CheckCmdResp($) {
 			$hash->{keepalive}{ok}    = 0;
 			$hash->{keepalive}{retry} = 0;
 			InternalTimer(gettimeofday() + SDUINO_KEEPALIVE_TIMEOUT, "SIGNALduino_KeepAlive", $hash, 0);
-		 	$hash->{hasCC1101} = 1  if ($ver =~ m/cc1101/);
+		 	$hash->{CC1101_Available} = 1  if ($ver =~ m/cc1101/);
 		}
 	}
 	else {

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckCmdResp-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckCmdResp-definition.txt
@@ -53,7 +53,7 @@ defmod test_sub_SIGNALduino_CheckCmdResp UnitTest dummyDuino (
 
 		is($targetHash->{ucCmd}->{cmd},"version","ucCmd not removed");
 		is($targetHash->{DevState},"initialized","check DevState");
-		is($targetHash->{hasCC1101},undef,"check internal hasCC1101");
+		is($targetHash->{CC1101_Available},undef,"check internal CC1101_Available");
 		$SD_SimpleWrite->unmock;
 	}; 
 
@@ -71,7 +71,7 @@ defmod test_sub_SIGNALduino_CheckCmdResp UnitTest dummyDuino (
 
 		is($targetHash->{ucCmd}->{cmd},"version","ucCmd not removed");
 		is($targetHash->{DevState},"initialized","check DevState");
-		is($targetHash->{hasCC1101},1,"check internal hasCC1101");
+		is($targetHash->{CC1101_Available},1,"check internal CC1101_Available");
 		
 		$SD_SimpleWrite->unmock;
 	}; 

--- a/UnitTest/tests/test_sub_SIGNALduino_Get-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Get-definition.txt
@@ -19,7 +19,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
     my @mockData = (
 	    {
 			testname	=> "get version",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "version",
 			check =>  array  {
 			    	item("V");
@@ -28,7 +28,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get freeram",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "freeram",
 			check =>  array  {
 			    	item("R");
@@ -37,7 +37,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get uptime",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "uptime",
 			check =>  array  {
 			    	item("t");
@@ -46,14 +46,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ? ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "?",
 			check 		=>  array  {end(); },
 			return 		=> check_set match qr/^Unknown argument \?, choose one of.*/,!match qr/cc/
 	    },
 	    {
 			testname	=> "get ?",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			dummy		=> 0,
 			DIODev		=> 1,
 			input		=> "?",
@@ -62,7 +62,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ?",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			dummy		=> 0,
 			DIODev		=> 0,
 			input		=> "?",
@@ -71,7 +71,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ?",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			dummy		=> 1,
 			input		=> "?",
 			check 		=>  array  {end(); },
@@ -80,7 +80,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 
 	    {
 			testname	=> "get ping ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "ping",
 			check =>  array  {
 			    	item("P");
@@ -89,7 +89,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get config ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "config",
 			check =>  array  {
 			    	item("CG");
@@ -98,7 +98,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccconf ",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			input		=> "ccconf",
 			check =>  array  {
 			    	item("C0DnF");
@@ -107,14 +107,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccconf ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "ccconf",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
 	    },
 	    {
 			testname	=> "get ccreg 12",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			input		=> "ccreg 12",
 			check =>  array  {
 			    	item("C12");
@@ -123,7 +123,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 98 (invalid register)",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			input		=> "ccreg 98",
 			check =>  array  {
 			    	end();
@@ -132,7 +132,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 99 (all)",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			input		=> "ccreg 99",
 			check =>  array  {
 			    	item("C99");
@@ -141,14 +141,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 12 ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "ccreg 12",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
 	    },
 	    {
 			testname	=> "get ccpatable ",
-			hasCC1101	=> 1,
+			CC1101_Available	=> 1,
 			input		=> "ccpatable",
 			check =>  array  {
 			    	item("C3E");
@@ -157,7 +157,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccpatable ",
-			hasCC1101	=> 0,
+			CC1101_Available	=> 0,
 			input		=> "ccpatable",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
@@ -174,7 +174,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 		next if (!exists($element->{testname}));
 
 		# Mock cc1101	
-		$targetHash->{hasCC1101} = exists($element->{hasCC1101}) ? $element->{hasCC1101} : 0;
+		$targetHash->{CC1101_Available} = exists($element->{CC1101_Available}) ? $element->{CC1101_Available} : 0;
 
 		# Mock dummy	
 		CommandAttr(undef,"$target dummy $element->{dummy}") if (exists($element->{dummy}));	
@@ -186,7 +186,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 		$element->{pre_code}->() if (exists($element->{pre_code}));
 		$todo=$element->{todo}->() if (exists($element->{todo}));
 		
-		subtest "checking $element->{testname}". ($targetHash->{hasCC1101} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
+		subtest "checking $element->{testname}". ($targetHash->{CC1101_Available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
 			plan (2);	
 			
 			my $ret = SIGNALduino_Get($targetHash,$target,split(" ",$element->{input}));

--- a/UnitTest/tests/test_sub_SIGNALduino_Get_Callback-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Get_Callback-definition.txt
@@ -25,7 +25,7 @@ defmod test_sub_SIGNALduino_Get_Callback UnitTest dummyDuino
 	
 	subtest 'Test return values SIGNALduino_Get_Callback with correct parameters' => sub {
 		plan(4);
-		$targetHash->{hasCC1101} = 1;
+		$targetHash->{CC1101_Available} = 1;
 		
 		my $ret = SIGNALduino_Get_Callback($target,\&dummyCb, "ccreg 12");
 		is($ret,U,"check return SIGNALduino_Get_Callback");
@@ -38,7 +38,7 @@ defmod test_sub_SIGNALduino_Get_Callback UnitTest dummyDuino
 		ref_is($targetHash->{ucCmd}{responseSub}, \&dummyCb, "Verify callback stored in target hash");
 		is($targetHash->{ucCmd}{cmd}, "ccreg", "Verify called command stored in target hash");
 	
-		delete($targetHash->{hasCC1101});
+		delete($targetHash->{CC1101_Available});
 	};
 	
 	subtest 'Test SIGNALduino_read with callback' => sub {

--- a/UnitTest/tests/test_sub_SIGNALduino_Set-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Set-definition.txt
@@ -27,7 +27,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
     # Simple commands
     my @mockData = (
     	{	
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set raw W0D23#W0B22",
 			input	=>	"raw W0D23#W0B22",
 			check =>  sub { 
@@ -39,7 +39,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
     	{	
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set disableMessagetype MC",
 			input	=>	"disableMessagetype MC",
 			check =>  sub { 
@@ -50,7 +50,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 
 		},
     	{	
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set enableMessagetype MU",
 			input	=>	"enableMessagetype MU",
 			check =>  sub { 
@@ -73,7 +73,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		
 		{	
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set freq 868",
 			input	=>	"cc1101_freq 868",
 			check =>  sub { 
@@ -88,7 +88,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{	
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set freq 868",
 			input	=>	"cc1101_freq 868",
 			check =>  sub { 
@@ -99,7 +99,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver"
 		},
 		{	
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set freq (defaults to 433)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -114,7 +114,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    },	   
 		},
 		{	
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set freq (defaults to 433)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -128,7 +128,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 			pre_code => sub { CommandAttr(undef,"$target cc1101_frequency 868") ; },
 			post_code => sub { CommandDeleteAttr(undef,"$target cc1101_frequency") ; },
 
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname =>  "set freq (defaults to 868)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -144,7 +144,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set bWidth 102",
 			input	=>	"cc1101_bWidth 102",
 			check =>  sub { 
@@ -156,7 +156,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "Register 10 requsted"
 		},
 		{
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set bWidth 102",
 			input	=>	"cc1101_bWidth 102",
 			check =>  sub { 
@@ -167,7 +167,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver"
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set rAmpl 24",
 			input	=>	"cc1101_rAmpl 24",
 			check =>  sub { 
@@ -180,7 +180,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set sens 8",
 			input	=>	"cc1101_sens 8",
 			check =>  sub { 
@@ -193,7 +193,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set patable 5_dBm (cc1101_frequency=433)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { $attr{$target}{cc1101_frequency} = '433' },
@@ -207,7 +207,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set patable 5_dBm (cc1101_frequency=868)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { $attr{$target}{cc1101_frequency} = '868' },
@@ -221,7 +221,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set patable 5_dBm (default cc1101_frequency)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { delete($attr{$target}{cc1101_frequency}) },
@@ -263,7 +263,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500#F10AB85550A) with fixed frequency",
 			input	=>	"sendMsg P43#0101#R3#C500#F10AB85550A",
 			check =>  sub { 
@@ -273,7 +273,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500#F10AB85550A) with fixed frequency",
 			input	=>	"sendMsg P43#0101#R3#C500#F10AB85550A",
 			check =>  sub { 
@@ -283,7 +283,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500) with default frequency",
 			input	=>	"sendMsg P43#0101#R3#C500",
 			check =>  sub { 
@@ -293,7 +293,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500) with default frequency",
 			input	=>	"sendMsg P43#0101#R3#C500",
 			check =>  sub { 
@@ -322,7 +322,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    todo => sub { return todo("this test isn't finished"); }
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set cc1101_reg 0D23 2E22",
 			input	=>	"cc1101_reg 0D23 2E22",
 			check =>  sub { 
@@ -336,7 +336,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    },
 		},
 		{
-    		hasCC1101	=> 1,
+    		CC1101_Available	=> 1,
 			testname	=> "set cc1101_reg 0D23 3F55 (wrong register)",
 			input		=> "cc1101_reg 0D23 3F55",
 			check 		=> sub { 
@@ -347,7 +347,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => match qr/^ERROR: unknown register position/,
 		},
 		{
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			testname=>  "set cc1101_reg 0D23 0B22",
 			input	=>	"cc1101_reg 0D23 0B22",
 			check =>  sub { 
@@ -358,7 +358,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver",
 		},
 		{
-    		hasCC1101 => 1,
+    		CC1101_Available => 1,
 			testname=>  "set cc1101_regSet AP23 FF22 (wrong register, nonhex)",
 			input	=>	"cc1101_reg AP23 FF22",
 			check =>  sub { 
@@ -370,7 +370,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname=>  "set bad command",
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			input	=>	"bla",
 			check =>  sub { 
 			    return array  {
@@ -381,7 +381,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname=>  "set ? command",
-    		hasCC1101 => 0,
+    		CC1101_Available => 0,
 			input	=>	"?",
 			check =>  sub { 
 			    return array  {
@@ -391,7 +391,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => check_set match qr/^Unknown argument \?, choose one of.*/,!match qr/cc/
 		},
 		{
-			hasCC1101 	=> 1,
+			CC1101_Available 	=> 1,
 			dummy 		=> 0,
 			DIODev		=> 1,
 			testname=>  "set ? command",
@@ -406,7 +406,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		{
 			testname	=>  "set ? command for dummy",
 			dummy 		=> 1,
-			hasCC1101 => 0,
+			CC1101_Available => 0,
 			input		=>	"?",
 			check 		=>  sub { 
 			    return array  {
@@ -418,7 +418,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		{
 			testname	=>  "set ? command for dummy",
 			dummy 		=> 1,
-			hasCC1101 	=> 1,
+			CC1101_Available 	=> 1,
 			check =>  sub { 
 			    return array  {
 			    	end();
@@ -429,7 +429,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname	=>  "set ? command for inactive device",
-			hasCC1101 	=> 1,
+			CC1101_Available 	=> 1,
 			DIODev		=> 0,
 			pre_code 	=> sub { $targetHash->{DevState} = 'disconnected' },
 			post_code	=> sub { $targetHash->{DevState} = 'initialized' },
@@ -443,7 +443,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname	=>  "set reset command for inactive device",
-			hasCC1101 	=> 1,
+			CC1101_Available 	=> 1,
 			dummy 		=> 1,
 			DIODev		=> 0,
 			pre_code 	=> sub { $targetHash->{DevState} = 'disconnected' },
@@ -466,7 +466,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		next if (!exists($element->{testname}));
 		
 		# Mock cc1101	
-		$targetHash->{hasCC1101} = exists($element->{hasCC1101}) ? $element->{hasCC1101} : 0;
+		$targetHash->{CC1101_Available} = exists($element->{CC1101_Available}) ? $element->{CC1101_Available} : 0;
 
 		# Mock dummy	
 		CommandAttr(undef,"$target dummy $element->{dummy}") if (exists($element->{dummy}));	
@@ -478,7 +478,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		$element->{pre_code}->() if (exists($element->{pre_code}));
 		$todo=$element->{todo}->() if (exists($element->{todo}));
 		
-		subtest "checking $element->{testname}". ($targetHash->{hasCC1101} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
+		subtest "checking $element->{testname}". ($targetHash->{CC1101_Available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
 			plan (2);	
 			
 			my $ret = SIGNALduino_Set($targetHash,$target,split(" ",$element->{input}));
@@ -519,7 +519,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 				is(AttrVal($target, "dummy", 0),0,"check attrib dummy is 0");
 				$targetHash->{DIODev} = 1;
 				CommandDeleteAttr($targetHash,"$target hardware") if (AttrVal($target, "hardware", undef));
-				delete($targetHash->{hasCC1101}) if ($targetHash->{hasCC1101});
+				delete($targetHash->{CC1101_Available}) if ($targetHash->{CC1101_Available});
 				is(AttrVal($target, "hardware", undef),undef,"check attrib hardware undef");
 				ok(DevIo_IsOpen($targetHash),"check DevIo_IsOpen returns true");
 			};


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
better overview

* **What is the current behavior?** (You can also link to an open issue here)
no grouping cc1101

Internals | value
-- | --
CC1101_CONFIG | freq:433.920MHz bWidth:325KHz rAmpl:42dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)
.
.
.
hasCC1101 | 1

* **What is the new behavior (if this is a feature change)?**
grouping cc1101

Internals | value
-- | --
CC1101_Available | 1
CC1101_CONFIG | freq:433.920MHz bWidth:325KHz rAmpl:42dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)