### PR TITLE
Update 00_SIGNALduino.pm

### DIFF
--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -31,7 +31,7 @@ use lib::SD_Protocols;
 
 
 use constant {
-	SDUINO_VERSION            => "v3.4.2_dev_10.01",
+	SDUINO_VERSION            => "v3.4.2_dev_20.01",
 	SDUINO_INIT_WAIT_XQ       => 1.5,       # wait disable device
 	SDUINO_INIT_WAIT          => 2,
 	SDUINO_INIT_MAXRETRY      => 3,
@@ -4781,6 +4781,9 @@ sub SetSens {
 		<li><b>LASTDMSGID</b>: This shows the last dispatched Protocol ID.</li>
 		<li><b>NR_CMD_LAST_H</b>: Number of messages sent within the last hour.</li>
 		<li><b>RAWMSG</b>: last received RAWMSG</li>
+		<li><b>cc1101_available</b>: If a CC1101 was detected, this internal is displayed with the value 1.</li>
+		<li><b>cc1101_config</b>: The configuration of the CC1101 is output here. The values ​​for frequency, bandwidth, rAmpl, sens and DataRate are output.</li>
+		<li><b>cc1101_config_ext</b>: The extended configuration information of the CC1101 is displayed here. The modulation and sync mod of the CC1101 are output.</li>
 		<li><b>version</b>: This shows the version of the SIGNALduino microcontroller.</li>
 		<li><b>versionProtocols</b>: This shows the version of SIGNALduino protocol file.</li>
 		<li><b>versionmodule</b>: This shows the version of the SIGNALduino FHEM module itself.</li>
@@ -5206,10 +5209,13 @@ When set to 1, the internal "RAWMSG" will not be updated with the received messa
 	<a name="SIGNALduinointernals"></a>
 	<b>Internals</b>
 	<ul>
-		<li><b>IDsNoDispatch</b>: Hier werden protokoll Eintr&auml;ge mit ihrer numerischen ID aufgelistet, f&uuml;r welche keine Weitergabe von Daten an logische Module aktiviert wurde. Um die Weitergabe zu aktivieren, kann die Men&uuml;option <a href="#SIGNALduinoDetail">Display protocollist</a> verwendet werden.</li>
+		<li><b>IDsNoDispatch</b>: Hier werden Protokolleintr&auml;ge mit ihrer numerischen ID aufgelistet, f&uuml;r welche keine Weitergabe von Daten an logische Module aktiviert wurde. Um die Weitergabe zu aktivieren, kann die Men&uuml;option <a href="#SIGNALduinoDetail">Display protocollist</a> verwendet werden.</li>
 		<li><b>LASTDMSGID</b>: Hier wird die zuletzt dispatchte Protocol ID angezeigt.</li>
 		<li><b>NR_CMD_LAST_H</b>: Anzahl der gesendeten Nachrichten innerhalb der letzten Stunde.</li>
 		<li><b>RAWMSG</b>: zuletzt empfangene RAWMSG</li>
+		<li><b>cc1101_available</b>: Wenn ein CC1101 erkannt wurde, so wird dieses Internal angezeigt mit dem Wert 1.</li>
+		<li><b>cc1101_config</b>: Hier wird die Konfiguration des CC1101 ausgegeben. Die Werte für Frquenz, Bandwidth, rAmpl, sens und DataRate werden ausgegeben.</li>
+		<li><b>cc1101_config_ext</b>: Hier werden die erweiterten Informationen der Konfiguration des CC1101 angezeigt. Die Modulation und der Syncmod des CC1101 werden ausgegeben.</li>
 		<li><b>version</b>: Hier wird die Version des SIGNALduino microcontrollers angezeigt.</li>
 		<li><b>versionProtocols</b>: Hier wird die Version der SIGNALduino Protokolldatei angezeigt.</li>
 		<li><b>versionmodule</b>: Hier wird die Version des SIGNALduino FHEM Modules selbst angezeigt.</li>

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -125,6 +125,8 @@ my %sets = (
 
 
 my @modformat = ("2-FSK","GFSK","-","ASK/OOK","4-FSK","-","-","MSK"); # modulation format
+my @syncmod = ("No preamble/sync","15/16 sync word bits detected","16/16 sync word bits detected","30/32 sync word bits detected", 
+               "No preamble/sync, carrier-sense above threshold, carrier-sense above threshold", "15/16 + carrier-sense above threshold", "16/16 + carrier-sense above threshold", "30/32 + carrier-sense above threshold");
 
 my %cc1101_register = (		# for get ccreg 99 and set cc1101_reg
  	"00" => 'IOCFG2  ',			# ! the values with spaces for output get ccreg 99 !
@@ -1047,13 +1049,14 @@ sub SIGNALduino_CheckccConfResponse
 		$var = substr($str,(hex($a)-13)*2, 2);
 		$r{$a} = hex($var);
 	}
-	my $msg = sprintf("freq:%.3fMHz bWidth:%dKHz rAmpl:%ddB sens:%ddB (DataRate:%.2fBaud, Modulation:%s)",
+	my $msg = sprintf("\n\nFrequency:  %.3f MHz\nBandwidth:  %d KHz\nrAmpl:      %d dB\nsens:       %d dB\nData Rate:  %.2f Baud\nModulation: %s\nSyncmode:   %s",
 		26*(($r{"0D"}*256+$r{"0E"})*256+$r{"0F"})/65536,                #Freq       | Register 0x0D,0x0E,0x0F
 		26000/(8 * (4+(($r{"10"}>>4)&3)) * (1 << (($r{"10"}>>6)&3))),   #Bw         | Register 0x10
 		$ampllist[$r{"1B"}&7],                                          #rAmpl      | Register 0x1B
 		4+4*($r{"1D"}&3),                                               #Sens       | Register 0x1D
 		((256+$r{"11"})*(2**($r{"10"} & 15 )))*26000000/(2**28),        #DataRate   | Register 0x10,0x11
-		$modformat[$r{"12"}>>4]                                         #Modulation | Register 0x12
+		$modformat[$r{"12"}>>4],                                        #Modulation | Register 0x12
+		$syncmod[($r{"12"})&7]                                          #Syncmod    | Register 0x12
 	);
 	$_[0]->{CC1101_CONFIG} = $msg;
 	return ($msg,undef);

--- a/FHEM/00_SIGNALduino.pm
+++ b/FHEM/00_SIGNALduino.pm
@@ -1049,7 +1049,7 @@ sub SIGNALduino_CheckccConfResponse
 		$var = substr($str,(hex($a)-13)*2, 2);
 		$r{$a} = hex($var);
 	}
-	my $msg = sprintf("Frequency: %.3fMHz, Bandwidth: %dKHz, rAmpl: %ddB, sens: %ddB, DataRate: %.2fBaud",
+	my $msg = sprintf("Freq: %.3f MHz, Bandwidth: %d KHz, rAmpl: %d dB, sens: %d dB, DataRate: %.2f Baud",
 		26*(($r{"0D"}*256+$r{"0E"})*256+$r{"0F"})/65536,                #Freq       | Register 0x0D,0x0E,0x0F
 		26000/(8 * (4+(($r{"10"}>>4)&3)) * (1 << (($r{"10"}>>6)&3))),   #Bw         | Register 0x10
 		$ampllist[$r{"1B"}&7],                                          #rAmpl      | Register 0x1B
@@ -1063,7 +1063,7 @@ sub SIGNALduino_CheckccConfResponse
 	);
 
 	$_[0]->{cc1101_config} = $msg;
-	$_[0]->{cc1101_config_plus} = $msg2;
+	$_[0]->{cc1101_config_ext} = $msg2;
 	return ($msg.", ".$msg2,undef);
 }
 

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckCmdResp-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckCmdResp-definition.txt
@@ -53,7 +53,7 @@ defmod test_sub_SIGNALduino_CheckCmdResp UnitTest dummyDuino (
 
 		is($targetHash->{ucCmd}->{cmd},"version","ucCmd not removed");
 		is($targetHash->{DevState},"initialized","check DevState");
-		is($targetHash->{CC1101_Available},undef,"check internal CC1101_Available");
+		is($targetHash->{cc1101_available},undef,"check internal cc1101_available");
 		$SD_SimpleWrite->unmock;
 	}; 
 
@@ -71,7 +71,7 @@ defmod test_sub_SIGNALduino_CheckCmdResp UnitTest dummyDuino (
 
 		is($targetHash->{ucCmd}->{cmd},"version","ucCmd not removed");
 		is($targetHash->{DevState},"initialized","check DevState");
-		is($targetHash->{CC1101_Available},1,"check internal CC1101_Available");
+		is($targetHash->{cc1101_available},1,"check internal cc1101_available");
 		
 		$SD_SimpleWrite->unmock;
 	}; 

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
@@ -4,8 +4,8 @@ defmod test_sub_SIGNALduino_CheckccConfResponse UnitTest dummyDuino (
 		plan tests => 2;
 		
 		my ($ret)=SIGNALduino_CheckccConfResponse($targetHash,"C0Dn11=10B07157C43023B900070018146C070091");
-		is($ret,"\n\nFrequency:  %.3f MHz\nBandwidth:  %d KHz\nrAmpl:      %d dB\nsens:       %d dB\nData Rate:  %.2f Baud\nModulation: %s\nSyncmode:   %s","check return message");
-		is($targetHash->{CC1101_CONFIG},"freq:433.920MHz bWidth:325KHz rAmpl:42dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)","check internal value");
+		is($ret,"\n\nFrequency:  433.920 MHz\nBandwidth:  325 KHz\nrAmpl:      42 dB\nsens:       8 dB\nData Rate:  5603.79 Baud\nModulation: ASK/OOK\nSyncmode:   No preamble/sync","check return message");
+		is($targetHash->{CC1101_CONFIG},"\n\nFrequency:  433.920 MHz\nBandwidth:  325 KHz\nrAmpl:      42 dB\nsens:       8 dB\nData Rate:  5603.79 Baud\nModulation: ASK/OOK\nSyncmode:   No preamble/sync","check internal value");
 	}; 
 	
 }

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
@@ -1,12 +1,12 @@
 defmod test_sub_SIGNALduino_CheckccConfResponse UnitTest dummyDuino ( 
 {
 	subtest 'Test cconf response (C0Dn11=10B07157C43023B900070018146C070091)' => sub {
-		plan tests => 2;
+		plan tests => 3;
 		
 		my ($ret)=SIGNALduino_CheckccConfResponse($targetHash,"C0Dn11=10B07157C43023B900070018146C070091");
-		is($ret,"\n\nFrequency:  433.920 MHz\nBandwidth:  325 KHz\nrAmpl:      42 dB\nsens:       8 dB\nData Rate:  5603.79 Baud\nModulation: ASK/OOK\nSyncmode:   No preamble/sync","check return message");
-		is($targetHash->{CC1101_CONFIG},"\n\nFrequency:  433.920 MHz\nBandwidth:  325 KHz\nrAmpl:      42 dB\nsens:       8 dB\nData Rate:  5603.79 Baud\nModulation: ASK/OOK\nSyncmode:   No preamble/sync","check internal value");
+		is($ret,"Frequency: 433.920MHz, Bandwidth: 325KHz, rAmpl: 42dB, sens: 8dB, DataRate: 5603.79Baud, Modulation: ASK/OOK, Syncmod: No preamble/sync","check return message");
+		is($targetHash->{cc1101_config},"Frequency: 433.920MHz, Bandwidth: 325KHz, rAmpl: 42dB, sens: 8dB, DataRate: 5603.79Baud","check internal cc1101_config value");
+		is($targetHash->{cc1101_config_plus},"Modulation: ASK/OOK, Syncmod: No preamble/sync","check internal cc1101_config_plus value");
 	}; 
-	
 }
 )

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
@@ -4,7 +4,7 @@ defmod test_sub_SIGNALduino_CheckccConfResponse UnitTest dummyDuino (
 		plan tests => 2;
 		
 		my ($ret)=SIGNALduino_CheckccConfResponse($targetHash,"C0Dn11=10B07157C43023B900070018146C070091");
-		is($ret,"freq:433.920MHz bWidth:325KHz rAmpl:42dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)","check return message");
+		is($ret,"\n\nFrequency:  %.3f MHz\nBandwidth:  %d KHz\nrAmpl:      %d dB\nsens:       %d dB\nData Rate:  %.2f Baud\nModulation: %s\nSyncmode:   %s","check return message");
 		is($targetHash->{CC1101_CONFIG},"freq:433.920MHz bWidth:325KHz rAmpl:42dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)","check internal value");
 	}; 
 	

--- a/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_CheckccConfResponse-definition.txt
@@ -4,9 +4,9 @@ defmod test_sub_SIGNALduino_CheckccConfResponse UnitTest dummyDuino (
 		plan tests => 3;
 		
 		my ($ret)=SIGNALduino_CheckccConfResponse($targetHash,"C0Dn11=10B07157C43023B900070018146C070091");
-		is($ret,"Frequency: 433.920MHz, Bandwidth: 325KHz, rAmpl: 42dB, sens: 8dB, DataRate: 5603.79Baud, Modulation: ASK/OOK, Syncmod: No preamble/sync","check return message");
-		is($targetHash->{cc1101_config},"Frequency: 433.920MHz, Bandwidth: 325KHz, rAmpl: 42dB, sens: 8dB, DataRate: 5603.79Baud","check internal cc1101_config value");
-		is($targetHash->{cc1101_config_plus},"Modulation: ASK/OOK, Syncmod: No preamble/sync","check internal cc1101_config_plus value");
+		is($ret,"Freq: 433.920 MHz, Bandwidth: 325 KHz, rAmpl: 42 dB, sens: 8 dB, DataRate: 5603.79 Baud, Modulation: ASK/OOK, Syncmod: No preamble/sync","check return message");
+		is($targetHash->{cc1101_config},"Freq: 433.920 MHz, Bandwidth: 325 KHz, rAmpl: 42 dB, sens: 8 dB, DataRate: 5603.79 Baud","check internal cc1101_config value");
+		is($targetHash->{cc1101_config_ext},"Modulation: ASK/OOK, Syncmod: No preamble/sync","check internal cc1101_config_ext value");
 	}; 
 }
 )

--- a/UnitTest/tests/test_sub_SIGNALduino_Get-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Get-definition.txt
@@ -19,7 +19,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
     my @mockData = (
 	    {
 			testname	=> "get version",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "version",
 			check =>  array  {
 			    	item("V");
@@ -28,7 +28,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get freeram",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "freeram",
 			check =>  array  {
 			    	item("R");
@@ -37,7 +37,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get uptime",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "uptime",
 			check =>  array  {
 			    	item("t");
@@ -46,14 +46,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ? ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "?",
 			check 		=>  array  {end(); },
 			return 		=> check_set match qr/^Unknown argument \?, choose one of.*/,!match qr/cc/
 	    },
 	    {
 			testname	=> "get ?",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			dummy		=> 0,
 			DIODev		=> 1,
 			input		=> "?",
@@ -62,7 +62,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ?",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			dummy		=> 0,
 			DIODev		=> 0,
 			input		=> "?",
@@ -71,7 +71,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ?",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			dummy		=> 1,
 			input		=> "?",
 			check 		=>  array  {end(); },
@@ -80,7 +80,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 
 	    {
 			testname	=> "get ping ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "ping",
 			check =>  array  {
 			    	item("P");
@@ -89,7 +89,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get config ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "config",
 			check =>  array  {
 			    	item("CG");
@@ -98,7 +98,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccconf ",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			input		=> "ccconf",
 			check =>  array  {
 			    	item("C0DnF");
@@ -107,14 +107,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccconf ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "ccconf",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
 	    },
 	    {
 			testname	=> "get ccreg 12",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			input		=> "ccreg 12",
 			check =>  array  {
 			    	item("C12");
@@ -123,7 +123,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 98 (invalid register)",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			input		=> "ccreg 98",
 			check =>  array  {
 			    	end();
@@ -132,7 +132,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 99 (all)",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			input		=> "ccreg 99",
 			check =>  array  {
 			    	item("C99");
@@ -141,14 +141,14 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccreg 12 ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "ccreg 12",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
 	    },
 	    {
 			testname	=> "get ccpatable ",
-			CC1101_Available	=> 1,
+			cc1101_available	=> 1,
 			input		=> "ccpatable",
 			check =>  array  {
 			    	item("C3E");
@@ -157,7 +157,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 	    },
 	    {
 			testname	=> "get ccpatable ",
-			CC1101_Available	=> 0,
+			cc1101_available	=> 0,
 			input		=> "ccpatable",
 			check =>  array  { end();	},
     		return 		=> "This command is only available with a cc1101 receiver"
@@ -174,7 +174,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 		next if (!exists($element->{testname}));
 
 		# Mock cc1101	
-		$targetHash->{CC1101_Available} = exists($element->{CC1101_Available}) ? $element->{CC1101_Available} : 0;
+		$targetHash->{cc1101_available} = exists($element->{cc1101_available}) ? $element->{cc1101_available} : 0;
 
 		# Mock dummy	
 		CommandAttr(undef,"$target dummy $element->{dummy}") if (exists($element->{dummy}));	
@@ -186,7 +186,7 @@ defmod test_sub_SIGNALduino_Get UnitTest dummyDuino
 		$element->{pre_code}->() if (exists($element->{pre_code}));
 		$todo=$element->{todo}->() if (exists($element->{todo}));
 		
-		subtest "checking $element->{testname}". ($targetHash->{CC1101_Available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
+		subtest "checking $element->{testname}". ($targetHash->{cc1101_available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
 			plan (2);	
 			
 			my $ret = SIGNALduino_Get($targetHash,$target,split(" ",$element->{input}));

--- a/UnitTest/tests/test_sub_SIGNALduino_Get_Callback-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Get_Callback-definition.txt
@@ -25,7 +25,7 @@ defmod test_sub_SIGNALduino_Get_Callback UnitTest dummyDuino
 	
 	subtest 'Test return values SIGNALduino_Get_Callback with correct parameters' => sub {
 		plan(4);
-		$targetHash->{CC1101_Available} = 1;
+		$targetHash->{cc1101_available} = 1;
 		
 		my $ret = SIGNALduino_Get_Callback($target,\&dummyCb, "ccreg 12");
 		is($ret,U,"check return SIGNALduino_Get_Callback");
@@ -38,7 +38,7 @@ defmod test_sub_SIGNALduino_Get_Callback UnitTest dummyDuino
 		ref_is($targetHash->{ucCmd}{responseSub}, \&dummyCb, "Verify callback stored in target hash");
 		is($targetHash->{ucCmd}{cmd}, "ccreg", "Verify called command stored in target hash");
 	
-		delete($targetHash->{CC1101_Available});
+		delete($targetHash->{cc1101_available});
 	};
 	
 	subtest 'Test SIGNALduino_read with callback' => sub {

--- a/UnitTest/tests/test_sub_SIGNALduino_Set-definition.txt
+++ b/UnitTest/tests/test_sub_SIGNALduino_Set-definition.txt
@@ -27,7 +27,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
     # Simple commands
     my @mockData = (
     	{	
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set raw W0D23#W0B22",
 			input	=>	"raw W0D23#W0B22",
 			check =>  sub { 
@@ -39,7 +39,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
     	{	
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set disableMessagetype MC",
 			input	=>	"disableMessagetype MC",
 			check =>  sub { 
@@ -50,7 +50,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 
 		},
     	{	
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set enableMessagetype MU",
 			input	=>	"enableMessagetype MU",
 			check =>  sub { 
@@ -73,7 +73,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		
 		{	
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set freq 868",
 			input	=>	"cc1101_freq 868",
 			check =>  sub { 
@@ -88,7 +88,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{	
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set freq 868",
 			input	=>	"cc1101_freq 868",
 			check =>  sub { 
@@ -99,7 +99,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver"
 		},
 		{	
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set freq (defaults to 433)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -114,7 +114,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    },	   
 		},
 		{	
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set freq (defaults to 433)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -128,7 +128,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 			pre_code => sub { CommandAttr(undef,"$target cc1101_frequency 868") ; },
 			post_code => sub { CommandDeleteAttr(undef,"$target cc1101_frequency") ; },
 
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname =>  "set freq (defaults to 868)",
 			input	=>	"cc1101_freq",
 			check =>  sub { 
@@ -144,7 +144,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set bWidth 102",
 			input	=>	"cc1101_bWidth 102",
 			check =>  sub { 
@@ -156,7 +156,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "Register 10 requsted"
 		},
 		{
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set bWidth 102",
 			input	=>	"cc1101_bWidth 102",
 			check =>  sub { 
@@ -167,7 +167,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver"
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set rAmpl 24",
 			input	=>	"cc1101_rAmpl 24",
 			check =>  sub { 
@@ -180,7 +180,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set sens 8",
 			input	=>	"cc1101_sens 8",
 			check =>  sub { 
@@ -193,7 +193,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set patable 5_dBm (cc1101_frequency=433)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { $attr{$target}{cc1101_frequency} = '433' },
@@ -207,7 +207,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set patable 5_dBm (cc1101_frequency=868)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { $attr{$target}{cc1101_frequency} = '868' },
@@ -221,7 +221,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set patable 5_dBm (default cc1101_frequency)",
 			input	=>	"cc1101_patable 5_dBm",
 			pre_code 	=> sub { delete($attr{$target}{cc1101_frequency}) },
@@ -263,7 +263,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500#F10AB85550A) with fixed frequency",
 			input	=>	"sendMsg P43#0101#R3#C500#F10AB85550A",
 			check =>  sub { 
@@ -273,7 +273,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500#F10AB85550A) with fixed frequency",
 			input	=>	"sendMsg P43#0101#R3#C500#F10AB85550A",
 			check =>  sub { 
@@ -283,7 +283,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500) with default frequency",
 			input	=>	"sendMsg P43#0101#R3#C500",
 			check =>  sub { 
@@ -293,7 +293,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    }
 		},
 		{
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set sendMsg ID:43 (P43#0101#R3#C500) with default frequency",
 			input	=>	"sendMsg P43#0101#R3#C500",
 			check =>  sub { 
@@ -322,7 +322,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    todo => sub { return todo("this test isn't finished"); }
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set cc1101_reg 0D23 2E22",
 			input	=>	"cc1101_reg 0D23 2E22",
 			check =>  sub { 
@@ -336,7 +336,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    },
 		},
 		{
-    		CC1101_Available	=> 1,
+    		cc1101_available	=> 1,
 			testname	=> "set cc1101_reg 0D23 3F55 (wrong register)",
 			input		=> "cc1101_reg 0D23 3F55",
 			check 		=> sub { 
@@ -347,7 +347,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => match qr/^ERROR: unknown register position/,
 		},
 		{
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			testname=>  "set cc1101_reg 0D23 0B22",
 			input	=>	"cc1101_reg 0D23 0B22",
 			check =>  sub { 
@@ -358,7 +358,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => "This command is only available with a cc1101 receiver",
 		},
 		{
-    		CC1101_Available => 1,
+    		cc1101_available => 1,
 			testname=>  "set cc1101_regSet AP23 FF22 (wrong register, nonhex)",
 			input	=>	"cc1101_reg AP23 FF22",
 			check =>  sub { 
@@ -370,7 +370,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname=>  "set bad command",
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			input	=>	"bla",
 			check =>  sub { 
 			    return array  {
@@ -381,7 +381,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname=>  "set ? command",
-    		CC1101_Available => 0,
+    		cc1101_available => 0,
 			input	=>	"?",
 			check =>  sub { 
 			    return array  {
@@ -391,7 +391,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		    return => check_set match qr/^Unknown argument \?, choose one of.*/,!match qr/cc/
 		},
 		{
-			CC1101_Available 	=> 1,
+			cc1101_available 	=> 1,
 			dummy 		=> 0,
 			DIODev		=> 1,
 			testname=>  "set ? command",
@@ -406,7 +406,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		{
 			testname	=>  "set ? command for dummy",
 			dummy 		=> 1,
-			CC1101_Available => 0,
+			cc1101_available => 0,
 			input		=>	"?",
 			check 		=>  sub { 
 			    return array  {
@@ -418,7 +418,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		{
 			testname	=>  "set ? command for dummy",
 			dummy 		=> 1,
-			CC1101_Available 	=> 1,
+			cc1101_available 	=> 1,
 			check =>  sub { 
 			    return array  {
 			    	end();
@@ -429,7 +429,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname	=>  "set ? command for inactive device",
-			CC1101_Available 	=> 1,
+			cc1101_available 	=> 1,
 			DIODev		=> 0,
 			pre_code 	=> sub { $targetHash->{DevState} = 'disconnected' },
 			post_code	=> sub { $targetHash->{DevState} = 'initialized' },
@@ -443,7 +443,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		},
 		{
 			testname	=>  "set reset command for inactive device",
-			CC1101_Available 	=> 1,
+			cc1101_available 	=> 1,
 			dummy 		=> 1,
 			DIODev		=> 0,
 			pre_code 	=> sub { $targetHash->{DevState} = 'disconnected' },
@@ -466,7 +466,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		next if (!exists($element->{testname}));
 		
 		# Mock cc1101	
-		$targetHash->{CC1101_Available} = exists($element->{CC1101_Available}) ? $element->{CC1101_Available} : 0;
+		$targetHash->{cc1101_available} = exists($element->{cc1101_available}) ? $element->{cc1101_available} : 0;
 
 		# Mock dummy	
 		CommandAttr(undef,"$target dummy $element->{dummy}") if (exists($element->{dummy}));	
@@ -478,7 +478,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 		$element->{pre_code}->() if (exists($element->{pre_code}));
 		$todo=$element->{todo}->() if (exists($element->{todo}));
 		
-		subtest "checking $element->{testname}". ($targetHash->{CC1101_Available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
+		subtest "checking $element->{testname}". ($targetHash->{cc1101_available} ? " with cc1101" : " without cc1101"). " " . ($targetHash->{DIODev} ? " devIo open" : " devIo closed") => sub {
 			plan (2);	
 			
 			my $ret = SIGNALduino_Set($targetHash,$target,split(" ",$element->{input}));
@@ -519,7 +519,7 @@ defmod test_sub_SIGNALduino_Set UnitTest dummyDuino
 				is(AttrVal($target, "dummy", 0),0,"check attrib dummy is 0");
 				$targetHash->{DIODev} = 1;
 				CommandDeleteAttr($targetHash,"$target hardware") if (AttrVal($target, "hardware", undef));
-				delete($targetHash->{CC1101_Available}) if ($targetHash->{CC1101_Available});
+				delete($targetHash->{cc1101_available}) if ($targetHash->{cc1101_available});
 				is(AttrVal($target, "hardware", undef),undef,"check attrib hardware undef");
 				ok(DevIo_IsOpen($targetHash),"check DevIo_IsOpen returns true");
 			};


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [x] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature, better view


* **What is the current behavior?** (You can also link to an open issue here)
```
ccconf: freq:433.920MHz bWidth:325KHz rAmpl:40dB sens:8dB (DataRate:5603.79Baud, Modulation:ASK/OOK)
```

* **What is the new behavior (if this is a feature change)?**
format output ccconf & new useful value

Variante 1 - Desktop return:
```
ccconf: 

Frequency:  433.920 MHz
Bandwidth:  325 KHz
rAmpl:      42 dB
sens:       8 dB
Data Rate:  5603.79 Baud
Modulation: ASK/OOK
Syncmode:   No preamble/sync
```
Internalvalue after cmd
```
Frequency:  433.920 MHz
Bandwidth:  325 KHz
rAmpl:      42 dB
sens:       8 dB
Data Rate:  5603.79 Baud
Modulation: ASK/OOK
Syncmode:   No preamble/sync
```

------------------------------
Variante 2 - Desktop return:
```
ccconf: Frequency: 433.920 MHz, Bandwidth: 325 KHz, rAmpl: 42 dB, sens: 4 dB
Data Rate: 5603.79 Baud, Modulation: ASK/OOK, Syncmode: No preamble/sync
```
Internalvalue after cmd
```
Frequency: 433.920 MHz, Bandwidth: 325 KHz, rAmpl: 42 dB, sens: 4 dB
Data Rate: 5603.79 Baud, Modulation: ASK/OOK, Syncmode: No preamble/sync
```