### PR TITLE
Dev r34 enhance autocreate test so that it doesn't need a new fhem instance

### DIFF
--- a/UnitTest/tests/test_autocreate_devices-definition.txt
+++ b/UnitTest/tests/test_autocreate_devices-definition.txt
@@ -12,7 +12,7 @@ defmod test_autocreate_devices UnitTest dummyDuino (
 	}
 
 	CommandAttr(undef,"autocreate verbose 5");
-
+	CommandAttr(undef,"global dupTimeout 0");
 	subtest 'attrib autocreate is undef for right result' => sub {
 		is(AttrVal("autocreate" ,"autocreateThreshold",undef),undef,"check autocreate undef");
 	};
@@ -20,14 +20,14 @@ defmod test_autocreate_devices UnitTest dummyDuino (
 	subtest 'Protocol 38 - autocreate via DMSG' => sub {
 		plan(3);
 		my $sensorname="SD_WS_38_T_1";
+		CommandDelete(undef,$sensorname);
 		for my $i (1..2) {
 			Dispatch($targetHash,"W38#8B922397E");
-			is(!IsDevice($sensorname), 1, "check sensor not created with dispatch $i/3");
-			sleep 3;
+			is(IsDevice($sensorname), 0, "check sensor not created with dispatch $i/3");
+			$targetHash->{TIME} -=3;
 		}
 		Dispatch($targetHash,"W38#8B922397E");
 		is(IsDevice($sensorname), 1, "check sensor created with dispatch 3");
-		sleep 3;
 		Dispatch($targetHash,"W38#8B922397E");
 	};
 	
@@ -36,8 +36,10 @@ defmod test_autocreate_devices UnitTest dummyDuino (
 		my $rmsg="MU;P0=32001;P1=-1939;P2=1967;P3=3896;P4=-3895;D=01213424242124212121242121242121212124212424212121212121242421212421242121242124242421242421242424242124212124242424242421212424212424212121242121212;CP=2;R=39;";
 		my %signal_parts=SIGNALduino_Split_Message($rmsg,$targetHash->{NAME});     
 		my $sensorname="BresserTemeo_1";
+		CommandDelete(undef,$sensorname);
+		
 		SIGNALduino_Parse_MU($targetHash, $targetHash, $targetHash->{NAME}, $rmsg,%signal_parts);
-		sleep 3;
+		$targetHash->{TIME} -=3;
 		is(!IsDevice($sensorname), 1, "Sensor not created with single dispatch");
 		SIGNALduino_Parse_MU($targetHash, $targetHash, $targetHash->{NAME}, $rmsg,%signal_parts);
 		is(IsDevice($sensorname), 1,"check Sensor created with second dispatch");
@@ -46,12 +48,14 @@ defmod test_autocreate_devices UnitTest dummyDuino (
 	subtest 'Protocol 84 - autocreate via DMSG' => sub {
 		plan(2);
 		my $sensorname="SD_WS_84_TH_1";
+		CommandDelete(undef,$sensorname);
 		Dispatch($targetHash,"W84#FE42004526");
-		is(!IsDevice($sensorname), 1, "Sensor not created with single dispatch");
-		sleep 3;
+		is(IsDevice($sensorname), 0, "Sensor not created with single dispatch");
+		$targetHash->{TIME} -=3;
+
 		Dispatch($targetHash,"W84#FE42004526");
 		is(IsDevice($sensorname), 1, "check Sensor created with second dispatch");
-		sleep 3;
+		$targetHash->{TIME} -=3;
 	};
 	
 	subtest 'Protocol 85 - autocreate via RAWMSG' => sub {
@@ -59,11 +63,12 @@ defmod test_autocreate_devices UnitTest dummyDuino (
 		my $rmsg="MU;P0=7944;P1=-724;P2=742;P3=241;P4=-495;P5=483;P6=-248;D=01212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634345656345634343456563421212121343434345656343434563434345634565656343434565634343434343434345634345634345634343434343434343434345634565634;CP=3;R=47;O;";      
 		my %signal_parts=SIGNALduino_Split_Message($rmsg,$targetHash->{NAME});     
 		my $sensorname="SD_WS_85_THW_1";
+		CommandDelete(undef,$sensorname);
 
-		for (my $i=1; $i <= 3; $i++) {
+		for my $i (1..3) {
 			SIGNALduino_Parse_MU($targetHash, $targetHash, $targetHash->{NAME}, $rmsg,%signal_parts);
-			sleep 3;
-			is(!IsDevice($sensorname), 1, "Sensor not created with dispatch $i/3");
+			is(IsDevice($sensorname), 0, "Sensor not created with dispatch $i/3");
+			$targetHash->{TIME} -=3;
 		}
 		SIGNALduino_Parse_MU($targetHash, $targetHash, $targetHash->{NAME}, $rmsg,%signal_parts);
 		is(IsDevice($sensorname), 1,"check Sensor created with dispatch 4");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix


* **What is the current behavior?** (You can also link to an open issue here)
If devices are already defined which should be defined via autocreate the test fails


* **What is the new behavior (if this is a feature change)?**
If devices are already defined which should be defined via autocreate the they are deleted 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:

Sleep time reduced by definig dupTimeout to 0 and change time of last received package