### PR TITLE
Added tests for parse Mx_ subs with corrupt data 

### DIFF
--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MN.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MN.t
@@ -1,0 +1,98 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use Test2::Tools::Compare qw{is item U D match hash array bag};
+use Mock::Sub;
+use Test2::Todo;
+
+
+
+my @mockData = (
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Good MN data],
+        input =>  q[MN;D=9AA6362CC8AAAA000012F8F4;R=4;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MN data, corrupt D=],
+        input =>  q[MN;D=9AA63&2CC8AAAA000012F8F4;R=4;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MN data, wrong delimiter ],
+        input =>  q[MN;D=9AA63&2CC8AAAA000012F8F4:R=4;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MN data, no D=  ],
+        input =>  q[MN;;R=4;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Good MN data, without RSSI],
+        input =>  q[MN;D=9AA63&2CC8AAAA000012F8F4;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+
+);
+plan (scalar @mockData );  
+
+BEGIN {
+};
+
+InternalTimer(time()+1, sub() {
+  while (@mockData)
+  {
+    my $element = pop(@mockData);
+
+    next if (!exists($element->{testname}));
+    FhemTestUtils_resetLogs();
+
+    my $targetHash = $defs{$element->{deviceName}};
+    my $todo =  (exists($element->{todoReason})) 
+      ? Test2::Todo->new(reason => $element->{todoReason})
+      : undef;
+
+    subtest "checking $element->{testname} on $element->{deviceName}" => sub {
+      my $p = $element->{plan} // 1;
+      plan ($p);  
+      my %signal_parts=SIGNALduino_Split_Message($element->{input},$element->{deviceName});   
+      
+      my $ret = SIGNALduino_Parse_MN($targetHash,$element->{input},\%signal_parts);
+      for my $i (1..$p)
+      {
+        $i == 1 && do { is($ret,$element->{rValue},"Verify return value") } ;
+        $i == 2 && do { is(FhemTestUtils_gotLog("PERL WARNING:"), 0, "No Warnings in logfile"); } ;
+      }
+
+
+    };
+    if (defined($todo)) {
+      $todo->end;
+    }
+
+  };
+
+  done_testing();
+  exit(0);
+
+}, 0);
+
+1;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MS.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MS.t
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use Test2::Tools::Compare qw{is item U D match hash array bag};
+use Mock::Sub;
+use Test2::Todo;
+
+
+
+my @mockData = (
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MS data, special chars],
+        input =>  q[MS;�=0;L=L=-1020;L=H=935;S=L=-525;S=H=444;D=354133323044313642333731303246303541423044364430;C==487;L==89;R==24;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MC data, special char and structure broken],
+        input =>  q[MS;P1=;L=L=-1015;L=H=944;S=L=-512;S=H=456;D=353531313436304235313330433137433244353036423130;C==487;L==89;R==45;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+
+    },
+);
+plan (scalar @mockData );  
+
+BEGIN {
+};
+
+InternalTimer(time()+1, sub() {
+  while (@mockData)
+  {
+    my $element = pop(@mockData);
+    next if (!exists($element->{testname}));
+    FhemTestUtils_resetLogs();
+
+    my $targetHash = $defs{$element->{deviceName}};
+    my $todo =  (exists($element->{todoReason})) 
+      ? Test2::Todo->new(reason => $element->{todoReason})
+      : undef;
+
+    subtest "checking $element->{testname} on $element->{deviceName}" => sub {
+      my $p = $element->{plan} // 1;
+      plan ($p);  
+      my %signal_parts=SIGNALduino_Split_Message($element->{input},$element->{deviceName});   
+      
+      my $ret = SIGNALduino_Parse_MS($targetHash,$targetHash,$element->{deviceName},$element->{input},%signal_parts);
+      for my $i (1..$p)
+      {
+        $i == 1 && do { is($ret,$element->{rValue},"Verify return value") } ;
+        $i == 2 && do { is(FhemTestUtils_gotLog("PERL WARNING:"), 0, "No Warnings in logfile"); } ;
+      }
+
+    };
+    if (defined($todo)) {
+      $todo->end;
+    }
+
+  };
+
+  done_testing();
+  exit(0);
+
+}, 0);
+
+1;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MU.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Parse_MU.t
@@ -1,0 +1,103 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use Test2::Tools::Compare qw{is item U D match hash array bag};
+use Mock::Sub;
+use Test2::Todo;
+
+
+
+my @mockData = (
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt Mu data, combined message],
+        input =>  q[MU;P0=-2272;P1=228;P2=-356;P3=635;P4=-562;P5=433;D=012345234345252343452523434345252345234343434523434345252343452525252525234523452343452345252525;CP=5;R=4�;P3=;L=L=-2864;L=H=2980;S=L=-1444;S=H=1509;D=354146333737463037;C==1466;L==32;R==9;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MU data, unknown specifier V=],
+        input =>  q[MU;P0=-1440;P1=432;P2=-357;P3=635;P4=-559;D=012121212123412343412123434121234343412123412343434341234343412123434121212121212341231212343412341212121;CP=1;V=139;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MU data, missing D= part],
+        input =>  q[MU;P0=-370;P1=632;P2=112;P3=-555;P4=428;P5=-780;P6=180;P7=;CP=4;R=77;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MU data, C= has letters ],
+        input =>  q[MU;P0=536;P1=-1443;P2=1486;P3=-4208;P4=5776;P5=-6700;P6=2972;P7=-2880;D=01212121212121212123456767212121212121672167212121212121212121672167672;C=23RB;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MU data, wrong delemiter =],
+        input =>  q[MU;P0=536;P1=-1443;P2=1486;P3=-4208;P4=5776;P5=-6700;P6=2972;P7=-2880;D=01212121212121212123456767212121212121672167212121212121212121672167672=C=23;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+    {
+        deviceName => q[dummyDuino],
+        plan => 2,
+        testname =>  q[Corrupt MU data, D= isn't numeric],
+        input =>  q[MU;P0=-16320;P1=394;P2=-400;P5=628;P6=-625;D=0121212121212121212121212561A1256121212121256121256125656C212561256561256121256121256565612565656121212125612125612121256121256125612561;CP=1;R=84;],
+        rValue => U(), 
+        todoReason => q[This data should not be processed]
+    },
+);
+plan (scalar @mockData );  
+
+BEGIN {
+};
+
+InternalTimer(time()+1, sub() {
+  while (@mockData)
+  {
+    my $element = pop(@mockData);
+    next if (!exists($element->{testname}));
+    FhemTestUtils_resetLogs();
+
+    my $targetHash = $defs{$element->{deviceName}};
+    my $todo =  (exists($element->{todoReason})) 
+      ? Test2::Todo->new(reason => $element->{todoReason})
+      : undef;
+
+    subtest "checking $element->{testname} on $element->{deviceName}" => sub {
+      my $p = $element->{plan} // 1;
+      plan ($p);  
+      my %signal_parts=SIGNALduino_Split_Message($element->{input},$element->{deviceName});   
+      
+      my $ret = SIGNALduino_Parse_MU($targetHash,$targetHash,$element->{deviceName},$element->{input},%signal_parts);
+      for my $i (1..$p)
+      {
+        $i == 1 && do { is($ret,$element->{rValue},"Verify return value") } ;
+        $i == 2 && do { is(FhemTestUtils_gotLog("PERL WARNING:"), 0, "No Warnings in logfile"); } ;
+      }
+
+    };
+    if (defined($todo)) {
+      $todo->end;
+    }
+
+  };
+
+  done_testing();
+  exit(0);
+
+}, 0);
+
+1;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [ ] CHANGED has been updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs and remove the other options -->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Unitests for parse_Mx subs


* **What is the current behavior?** (You can also link to an open issue here)

There are only unittests which good data and only the number of dispatches are counted


* **What is the new behavior (if this is a feature change)?**

Added tests with corrupt data

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

## SIGNALduino_Parse_MN
https://github.com/RFD-FHEM/RFFHEM/pull/920/checks?check_run_id=1606779153#step:9:739

## SIGNALduino_Parse_MU
https://github.com/RFD-FHEM/RFFHEM/pull/920/checks?check_run_id=1606779153#step:9:897

## SIGNALduino_Parse_MS
https://github.com/RFD-FHEM/RFFHEM/pull/920/checks?check_run_id=1606779153#step:9:846
