### PR TITLE
Fix broken actions - specify version tag explicit to avoid broken versions

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -10,14 +10,15 @@ jobs:
         perl: [ '5.22', '5.24', '5.26' ]
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@master
-    - uses: shogo82148/actions-setup-perl@v1
+    - uses: actions/checkout@v2
+    - uses: shogo82148/actions-setup-perl@v1.9.4
       with:
         perl-version: ${{ matrix.perl }}
-    - run: |
-        cpanm --notest --installdeps .
-        cpanm --notest Devel::Cover::Report::Clover
-        cpanm Storable
+    - name: Install deps via cpanm
+      run: |
+        cpanm --notest --no-interactive -v --installdeps .
+        cpanm --notest --no-interactive -v Devel::Cover::Report::Clover
+        cpanm --no-interactive -v Storable
     - name: install fhem via deb package
       run: |
         wget -qO - http://debian.fhem.de/archive.key | sudo apt-key add -
@@ -67,7 +68,6 @@ jobs:
 #       grep -oP "^make:.*\[(.*)\].*Error" make_error.txt | awk -F'[][]' '{print $2}'
       shell: bash {0}
     - name: Create clover report  
-#      run: cover -report codecov
       run: cover -report clover
     - uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,10 @@
 name: controlsFile
 
-on: [push]
+on:
+  push:
+    paths: 
+      - 'FHEM/**'
+      - '.github/workflows/update.yml'
 
 jobs:
   update:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,16 +12,16 @@ jobs:
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: extract_branch
     - name: Checkout Repostory
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
         persist-credentials: false
     - name: update controls files
-      uses: fhem/fhem-controls-actions@master
+      uses: fhem/fhem-controls-actions@v2
       with:
         filename: controls_signalduino.txt 
     - name: update controls files
-      uses: fhem/fhem-controls-actions@master
+      uses: fhem/fhem-controls-actions@v2
       with:
         filename: controls_signalduino.txt 
         directory: FHEM/lib
@@ -39,7 +39,7 @@ jobs:
         git ls-files --error-unmatch CHANGED || git add CHANGED
         git diff --name-only --exit-code controls_signalduino.txt || git commit CHANGED controls_signalduino.txt -m "Automatic updated controls and CHANGED" || true
     - name: git push
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GH_TOKEN }}
         branch: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
* **Other information**:

This PR does only update the github actions workflows

1. Versions are explicit specified for the used actions
2. the update workflow is only triggered if there is a change in the path FHEM/*  or on the workflow itself.
If files in other folders are changed there is no run.
