### PR TITLE
verify 1st Revolt checksum byte

### DIFF
--- a/CHANGED
+++ b/CHANGED
@@ -1,3 +1,8 @@
+2021-04-23 - 00_SIGNALduino.pm - verify Revolt checksums
+  SD_ProtocolData.pm: add new postDemo_Revolt which drops Revolt messages with
+                      invalid checksums
+  SD_Protocols.pm: drop Revolt messages without checksum byte
+
 2021-04-10 - FSK optimization (#953)
 
 * FSK optimization

--- a/FHEM/lib/SD_ProtocolData.pm
+++ b/FHEM/lib/SD_ProtocolData.pm
@@ -87,7 +87,7 @@ package lib::SD_ProtocolData;
   use strict;
   use warnings;
 
-  our $VERSION = '1.27';
+  our $VERSION = '1.28';
 
   our %protocols = (
     "0" =>  ## various weather sensors (500 | 9100)
@@ -1316,9 +1316,9 @@ package lib::SD_ProtocolData;
         preamble         => 'r',
         clientmodule     => 'Revolt',
         modulematch      => '^r[A-Fa-f0-9]{22}',
-        length_min       => '84',
+        length_min       => '96',
         length_max       => '120',
-        postDemodulation => sub { my $self=shift;  my ($name, @bit_msg) = @_;  my @new_bitmsg = splice @bit_msg, 0,88;  return 1,@new_bitmsg; },
+        postDemodulation => \&lib::SD_Protocols::postDemo_Revolt,
       },
     "46"  =>  ## Tedsen Fernbedienungen u.a. für Berner Garagentorantrieb GA401 und Geiger Antriebstechnik Rolladensteuerung
               # https://github.com/RFD-FHEM/RFFHEM/issues/91

--- a/t/SD_Protocols/02_postDemo_Revolt.t
+++ b/t/SD_Protocols/02_postDemo_Revolt.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test2::V0;
+use lib::SD_Protocols;
+use Test2::Tools::Compare qw{ is };
+
+my $Protocols =
+	new lib::SD_Protocols( filetype => 'json', filename => './t/SD_Protocols/test_protocolData.json' );
+my $target='some_device_name';
+
+plan(2);
+
+my $output;
+my $rcode;
+
+subtest 'Test CRC OK' => sub {
+	plan(2);
+	# MU;P0=143;P1=-218;P2=11620;P3=-332;P5=264;D=01230151515101015151015101515101510151515101015101010101010101010101010101010101010101015151010151010101010101010101010101010101010101010101010101010151015101010151010101015151015101510101010101510151015151010150;CP=0;R=0;
+	my @bits=qw(0 1 1 1 0 0 1 1 0 1 0 1 1 0 1 0 1 1 1 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 1 1 0 1 0 1 0 0 0 0 0 1 0 1 0 1 1 0 0 1);
+
+	($rcode,@bits)=lib::SD_Protocols::postDemo_Revolt($Protocols,$target,@bits);
+	is($rcode,1,'check returncode for postDemo_Revolt, CRC OK');
+	is(join("",@bits),'0111001101011010111001000000000000000000001100100000000000000000000000000101000100001101','check result postDemo_Revolt, CRC OK');
+};
+
+
+subtest 'Test CRC ERROR' => sub {
+	plan(2);
+	# MU;P1=10300;P2=-348;P3=112;P4=-254;P5=233;D=1234543434343434343434343434343434343434343434343434343454345454343454345434343454343454345434343454545434343434345454343434343434343434343434343454345454343454345434343454343454345434343454545434343434345450;CP=3;R=0;
+	my @bits=qw(0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 0 1 0 1 0 0 0 1 0 0 1 0 1 0 0 0 1 1 1 0 0 0 0 0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 0 1 0 1 0 0 0 1 0 0 1 0 1 0 0 0 1 1 1 0 0 0 0 0 1 1);
+
+	($rcode,$output)=lib::SD_Protocols::postDemo_Revolt($Protocols,$target,@bits);
+	is($rcode,0,'check returncode for postDemo_Revolt, CRC ERROR');
+	is($output,undef,'check result postDemo_Revolt, CRC ERROR');
+};


### PR DESCRIPTION
NOTE: This is a port of a patch developed for the svn.fhem.de version of SIGNALduino code, see also https://forum.fhem.de/index.php/topic,58397.msg1151053.html#msg1151053. I'm interested in getting this change into the SIGNALduino code distributed via svn.fhem.de, so I hope this project is the place to prepare changes for FHEM integration!

Change description:

To avoid wrong reads and especially invalid autocreates for Revolt NC-546x
energy cost meters, add verification of the 1st Revolt checksum byte.
Check based on (old) analysis from mehf, see Forum #14292. There's
another checksum(?) byte which I didn't understand yet.

Also increase minimum length of messages to assure we received the checksum
byte. In general, this patch might slightly decrease probability of receiving
far devices, but I think avoiding erronous reads is more important.

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)
- [x] CHANGED has been updated (needed for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the frequent reception of invalid messages leading to autocreation of non-existing devices by verifying the checksum.

* **What is the current behavior?** (You can also link to an open issue here)

I see frequent additions of non-existant Revolt devices (perhaps one per week) obviously caused by reception errors. Here's an example from a FHEM instance actually receiving two devices: 

![image](https://user-images.githubusercontent.com/2518769/115924590-3bbddd80-a480-11eb-8475-74077441d125.png)

* **What is the new behavior (if this is a feature change)?**

Drop messages without checksum byte or with invalid checksum.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

There might be seldom cases where this change prevents reception of far devices with incomplete messages as we'll drop any message without checksum byte which could be parsed before introducing my change.
