### PR TITLE
Update 02_SIGNALduino_calcRSSI.t - PERL WARNING eliminated

### DIFF
--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_calcRSSI.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_calcRSSI.t
@@ -42,9 +42,10 @@ InternalTimer(time()+1, sub {
 		note($rmsg);
 		my %signal_parts=SIGNALduino_Split_Message($rmsg,$targetHash->{NAME});
 		my $rssi=$signal_parts{rssi};
+		my $rssiStr;
 		plan(2);
 
-		my ($rssi,$rssiStr)=SIGNALduino_calcRSSI($rssi);
+		($rssi,$rssiStr)=SIGNALduino_calcRSSI($rssi);
 		is($rssi,-36.5,'check return value -36.5 for input '.$signal_parts{rssi});
 		is($rssiStr,'RSSI = -36.5','check return string RSSI = -36.5 for input '.$signal_parts{rssi});
 	};


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Unittest enhancement
- [x] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)
`2021-09-01T15:48:48.8853674Z ##[error]2021.09.01 15:48:44 1: PERL WARNING: "my" variable $rssi masks earlier declaration in same scope at /home/runner/work/RFFHEM/RFFHEM/t/FHEM/00_SIGNALduino/02_SIGNALduino_calcRSSI.t line 47.`

* **What is the new behavior (if this is a feature change)?**
`no PERL WARNING`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
