### PR TITLE
unittests - added PERL syntax for editors

### DIFF
--- a/t/FHEM/00_SIGNALduino/00_limit_subs.t
+++ b/t/FHEM/00_SIGNALduino/00_limit_subs.t
@@ -1,3 +1,4 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use File::Basename;
@@ -11,7 +12,7 @@ my $module = basename (dirname(__FILE__));
 
 plan(2);
 subtest 'limit_to_number tests' => sub {
-    
+
     plan(5);
 
     is(_limit_to_number(1),1,'limit 1 ok');
@@ -23,7 +24,7 @@ subtest 'limit_to_number tests' => sub {
 };
 
 subtest '_limit_to_hex tests' => sub {
-    
+
     plan(7);
 
     is(_limit_to_hex('AF'),'AF','limit AF ok'); 
@@ -33,7 +34,7 @@ subtest '_limit_to_hex tests' => sub {
     is(_limit_to_hex('PA0'),U(),'limit PA0 ok');
     is(_limit_to_hex('0xA0'),U(),'limit 0xA0 ok');
     is(_limit_to_hex(qw/DF SP/),'DF','limit (SL,SP) ok');
-    
+
 };
 
 exit(0);  # necessary

--- a/t/FHEM/00_SIGNALduino/00_load.t
+++ b/t/FHEM/00_SIGNALduino/00_load.t
@@ -1,3 +1,4 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use File::Basename;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_PatternExists.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_PatternExists.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_PrepareFlash.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_PrepareFlash.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is bag check array like unlike U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Set_sendMsg.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Set_sendMsg.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is item U D match hash array bag};
 use Mock::Sub;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Write.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Write.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is field U D match array hash bag };
 use Test2::Todo;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_avrdude.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_avrdude.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is bag check array like unlike U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_logging.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_logging.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckCcregResponse.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckCcregResponse.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ like unlike };
 our %defs;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckCmdResp.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckCmdResp.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckUptimeResponse.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckUptimeResponse.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckVersionResp.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckVersionResp.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is like };
 our %defs;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckccConfResponse.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckccConfResponse.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckccPatableResponse.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_CheckccPatableResponse.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Dispatch.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Dispatch.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_FingerprintFn.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_FingerprintFn.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is unlike like U check item array DNE};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_GetResponseUpdateReading.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_GetResponseUpdateReading.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 our %defs;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get_Callback.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get_Callback.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is like unlike check array U};
 use Test2::Tools::Ref;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get_delayed.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Get_delayed.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U};
 use Test2::Tools::Ref;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_RemoveLaCrossePair.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_RemoveLaCrossePair.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ U };
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_SendFromQueue.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_SendFromQueue.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is like check hash within field U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Set_flash.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Set_flash.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is bag check array like unlike U};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_Split_Message.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_Split_Message.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_StartInit.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_StartInit.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_calcRSSI.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_calcRSSI.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_callsub_1.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_callsub_1.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 use Test2::Tools::ClassicCompare qw/is_deeply/;

--- a/t/FHEM/00_SIGNALduino/02_SIGNALduino_getAttrDevelopment.t
+++ b/t/FHEM/00_SIGNALduino/02_SIGNALduino_getAttrDevelopment.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is };
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/02_sub_SIGNALduino_Read.t
+++ b/t/FHEM/00_SIGNALduino/02_sub_SIGNALduino_Read.t
@@ -1,6 +1,7 @@
 #!/bin/perl
 use strict;
 use warnings;
+
 use Test::Device::SerialPort;
 use Test2::V0;
 use Test2::Tools::Compare;

--- a/t/FHEM/00_SIGNALduino/03_SIGNALduino_Set.t
+++ b/t/FHEM/00_SIGNALduino/03_SIGNALduino_Set.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is bag check array like unlike};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/04_defineDefaults.t
+++ b/t/FHEM/00_SIGNALduino/04_defineDefaults.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 

--- a/t/FHEM/00_SIGNALduino/04_developid.t
+++ b/t/FHEM/00_SIGNALduino/04_developid.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is isnt};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/04_firmware_download.t
+++ b/t/FHEM/00_SIGNALduino/04_firmware_download.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is like unlike};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/04_modulematch.t
+++ b/t/FHEM/00_SIGNALduino/04_modulematch.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is isnt};
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/06_SIGNALduino_ResetDevice.t
+++ b/t/FHEM/00_SIGNALduino/06_SIGNALduino_ResetDevice.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Mock;

--- a/t/FHEM/00_SIGNALduino/08_DeviceData_rmsg.t
+++ b/t/FHEM/00_SIGNALduino/08_DeviceData_rmsg.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Mock;

--- a/t/FHEM/10_FS10/00_load.t
+++ b/t/FHEM/10_FS10/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/10_FS10/09_ParseData.t
+++ b/t/FHEM/10_FS10/09_ParseData.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use File::Basename;
 

--- a/t/FHEM/10_SD_GT/00_load.t
+++ b/t/FHEM/10_SD_GT/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/10_SD_GT/09_parseDatat.t
+++ b/t/FHEM/10_SD_GT/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_BresserTemeo/00_load.t
+++ b/t/FHEM/14_BresserTemeo/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_BresserTemeo/09_autocreate_devices.t
+++ b/t/FHEM/14_BresserTemeo/09_autocreate_devices.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 

--- a/t/FHEM/14_BresserTemeo/09_parseDatat.t
+++ b/t/FHEM/14_BresserTemeo/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_FLAMINGO/00_load.t
+++ b/t/FHEM/14_FLAMINGO/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_FLAMINGO/09_parseDatat.t
+++ b/t/FHEM/14_FLAMINGO/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_Hideki/00_load.t
+++ b/t/FHEM/14_Hideki/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_AS/00_load.t
+++ b/t/FHEM/14_SD_AS/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_BELL/00_load.t
+++ b/t/FHEM/14_SD_BELL/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_BELL/09_parseDatat.t
+++ b/t/FHEM/14_SD_BELL/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_SD_RSL/00_load.t
+++ b/t/FHEM/14_SD_RSL/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_UT/00_load.t
+++ b/t/FHEM/14_SD_UT/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_UT/09_parseDatat.t
+++ b/t/FHEM/14_SD_UT/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_SD_WS/00_load.t
+++ b/t/FHEM/14_SD_WS/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_WS/09_autocreate_devices.t
+++ b/t/FHEM/14_SD_WS/09_autocreate_devices.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is};
 

--- a/t/FHEM/14_SD_WS/09_parseDatat.t
+++ b/t/FHEM/14_SD_WS/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_SD_WS07/00_load.t
+++ b/t/FHEM/14_SD_WS07/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_WS07/09_parseDatat.t
+++ b/t/FHEM/14_SD_WS07/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_SD_WS09/00_load.t
+++ b/t/FHEM/14_SD_WS09/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/14_SD_WS09/09_parseDatat.t
+++ b/t/FHEM/14_SD_WS09/09_parseDatat.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/14_SD_WS_Maverick/00_load.t
+++ b/t/FHEM/14_SD_WS_Maverick/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/41_OREGON/00_load.t
+++ b/t/FHEM/41_OREGON/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/41_OREGON/09_parseData.t
+++ b/t/FHEM/41_OREGON/09_parseData.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{is U };
 use Test2::Todo;

--- a/t/FHEM/90_SIGNALduino_un/00_load.t
+++ b/t/FHEM/90_SIGNALduino_un/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/98_Dooya/00_load.t
+++ b/t/FHEM/98_Dooya/00_load.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use File::Basename;
 
 use Test2::V0;

--- a/t/FHEM/cc1101/01_func.t
+++ b/t/FHEM/cc1101/01_func.t
@@ -1,5 +1,7 @@
+#!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test2::V0;
 use Test2::Tools::Compare qw{ is array bag };
 use Test2::Todo;

--- a/t/SD_Protocols/01_LengthInRange.t
+++ b/t/SD_Protocols/01_LengthInRange.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/01_binStr2hexStr.t
+++ b/t/SD_Protocols/01_binStr2hexStr.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/01_dec2binppari.t
+++ b/t/SD_Protocols/01_dec2binppari.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/01_registerLogCallback.t
+++ b/t/SD_Protocols/01_registerLogCallback.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvBresser_5in1.t
+++ b/t/SD_Protocols/02_ConvBresser_5in1.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvBresser_6in1.t
+++ b/t/SD_Protocols/02_ConvBresser_6in1.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvHE800.t
+++ b/t/SD_Protocols/02_ConvHE800.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvHE_EU.t
+++ b/t/SD_Protocols/02_ConvHE_EU.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvITV1_tristateToBit.t
+++ b/t/SD_Protocols/02_ConvITV1_tristateToBit.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvKoppFreeControl.t
+++ b/t/SD_Protocols/02_ConvKoppFreeControl.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvLaCrosse.t
+++ b/t/SD_Protocols/02_ConvLaCrosse.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_ConvPCA301.t
+++ b/t/SD_Protocols/02_ConvPCA301.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_Convbit2Arctec.t
+++ b/t/SD_Protocols/02_Convbit2Arctec.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_Convbit2itv1.t
+++ b/t/SD_Protocols/02_Convbit2itv1.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_MCRAW.t
+++ b/t/SD_Protocols/02_MCRAW.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_PreparingSend_FS20_FHT.t
+++ b/t/SD_Protocols/02_PreparingSend_FS20_FHT.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_PreparingSend_KOPP_FC.t
+++ b/t/SD_Protocols/02_PreparingSend_KOPP_FC.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2AS.t
+++ b/t/SD_Protocols/02_mcBit2AS.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2Grothe.t
+++ b/t/SD_Protocols/02_mcBit2Grothe.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2Hideki.t
+++ b/t/SD_Protocols/02_mcBit2Hideki.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2Maverick.t
+++ b/t/SD_Protocols/02_mcBit2Maverick.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2OSPIR.t
+++ b/t/SD_Protocols/02_mcBit2OSPIR.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2OSV1.t
+++ b/t/SD_Protocols/02_mcBit2OSV1.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2OSV2o3.t
+++ b/t/SD_Protocols/02_mcBit2OSV2o3.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2SomfyRTS.t
+++ b/t/SD_Protocols/02_mcBit2SomfyRTS.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_mcBit2TFA.t
+++ b/t/SD_Protocols/02_mcBit2TFA.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_EM.t
+++ b/t/SD_Protocols/02_postDemo_EM.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_FHT80.t
+++ b/t/SD_Protocols/02_postDemo_FHT80.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_FHT80TF.t
+++ b/t/SD_Protocols/02_postDemo_FHT80TF.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_FS20.t
+++ b/t/SD_Protocols/02_postDemo_FS20.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_Revolt.t
+++ b/t/SD_Protocols/02_postDemo_Revolt.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_WS2000.t
+++ b/t/SD_Protocols/02_postDemo_WS2000.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_WS7035.t
+++ b/t/SD_Protocols/02_postDemo_WS7035.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_WS7053.t
+++ b/t/SD_Protocols/02_postDemo_WS7053.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 

--- a/t/SD_Protocols/02_postDemo_lenghtnPrefix.t
+++ b/t/SD_Protocols/02_postDemo_lenghtnPrefix.t
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Unittest enhancement
- [x] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)
  - some files have no `#!/usr/bin/env perl` line
--> some editors do not recognize language

* **What is the new behavior (if this is a feature change)?**
  - editors recognize language
--> simplified representation and thus a better overview

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
  - added `#!/usr/bin/env perl` on some testfiles --> nothing changed in individual tests
