### PR TITLE
Do not check order of rfmodes in test

### DIFF
--- a/t/FHEM/00_SIGNALduino/00_SIGNALduino_initialize.t
+++ b/t/FHEM/00_SIGNALduino/00_SIGNALduino_initialize.t
@@ -21,7 +21,7 @@ InternalTimer(time(), sub {
     my @rfmodes = split (",",$attrRFmodes);
     
     # Itmes must be in sorted order
-    is(\@rfmodes,array {
+    is(\@rfmodes,bag {
             item 'rfmode:Avantek';
             item 'Bresser_5in1';
             item 'Bresser_6in1';
@@ -32,9 +32,7 @@ InternalTimer(time(), sub {
             item 'Lacrosse_mode2';
             item 'PCA301';
             item 'Rojaflex';
-            item 'SlowRF';
-            
-            etc();
+            item 'SlowRF';            
         }    
      ,q[Test rfmodes and order]);
    


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Unittest enhancement
- [ ] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)

The test relies on the order of elements. Adding a rfmode needs extending the test.

#980


* **What is the new behavior (if this is a feature change)?**

The order of elements is not checked
Also there can be more elements


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
