### PR TITLE
Tool for testing FHEM commands against devices

### DIFF
--- a/lib/Test2/SIGNALduino/FHEM_Command.pm
+++ b/lib/Test2/SIGNALduino/FHEM_Command.pm
@@ -1,5 +1,38 @@
 package Test2::SIGNALduino::FHEM_Command;
 
+#  tests are defined via array of hashes @mock, which is injectd from the calling scope
+#   First Element in array can be a element which holds defaults
+#   currently only mocking is suppored as a defauld
+#    {
+#        # Default mocking for every testrun in our loop
+#        defaults    => {
+#            mocking =>  sub { $mock->override ( IOWrite => sub { return @_ } );  } 
+#        },
+#    },
+
+#    Defining a Test needs some*, but not all elements. More hints on Test2::SIGNALduino::FHEM_Command
+#    {	
+#      * targetName 	=> 	q[SD_UT_Test_6],			    # Name of the definition which is tested, must be defined before test starts
+#	   * testname       =>  q[set command fan_off],         # Name of our setcommand
+#      * cmd   	        =>	q[set fan_off],      			# Command to execute for test
+#        # Check for arguments given to mocked sub
+         # Anything from test2:compare can be used: https://metacpan.org/pod/Test2::Tools::Compare to verify called arguments for mocked sub
+#      * subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#111110111110#R5' }; etc() } } } ,  
+#      * returnCheck     => F(),                            # Check for false return from command
+#        prep_hash       => {                               # All Items listed here will be added to the devicehash bevore the test starts
+#            cc1101_available  =>  1,
+#            DIODev   =>  'open',
+#        },
+#        prep_commands   => [                               # Any FHEM custom command can be placed in here, which will be called before the test is run
+#			'set $targetName ?', 
+#        ],
+#        todo => 1, # Enable Todo block if item exists
+#    },
+
+#
+#
+#
+
 use strict;
 use warnings;
 use Test2::V0;
@@ -85,8 +118,8 @@ sub commandCheck {
     
     # Diable prototype mismatch warnings for redefined subs
     local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /redefined|Prototype mismatch:/ };
-
-	foreach my $element (@filt_testDataArray)
+    
+    foreach my $element (@filt_testDataArray)
 	{
 		next if (!exists($element->{testname}));
     	$mock->clear_sub_tracking();

--- a/lib/Test2/SIGNALduino/FHEM_Command.pm
+++ b/lib/Test2/SIGNALduino/FHEM_Command.pm
@@ -1,0 +1,145 @@
+package Test2::SIGNALduino::FHEM_Command;
+
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Tools::Compare qw{is U validator};
+use Test2::Todo;
+use Test2::Mock;
+use Test2::API qw/context run_subtest/;
+use base 'Exporter';
+our $mock;
+our @mockData;
+
+our @ISA = 'Exporter';
+our @EXPORT = qw/@mockData $mock/;
+our $VERSION = 1.00;
+
+my $EMPTY = q{};
+
+
+
+sub filterTestDataArray {
+  my $modulename = shift;
+
+  $modulename =~ s/^[0-9][0-9]_//; # Remove leading digtis
+  my @results;
+
+  return @results;
+}
+
+
+sub checkGet  {
+    my $element = shift;
+    my $targetHash = shift;
+
+    my $cmd = qq[$targetHash->{NAME} $element->{cmd}];
+    my $ret = main::CommandGet($targetHash,$cmd);
+
+    my $result  = is($mock->sub_tracking,$element->{subCheck},q[verify subroutine tracking]);
+    $result    &= is($ret,$element->{returnCheck},q[verify return value from command]);
+    
+    return $result;
+ }
+
+sub checkAttr  {
+    my $element = shift;
+    my $targetHash = shift;
+
+    my $cmd = qq[$targetHash->{NAME} $element->{cmd}];
+    my $ret = main::CommandAttr($targetHash,$cmd);
+
+    my $result  = is($mock->sub_tracking,$element->{subCheck},q[verify subroutine tracking]);
+    $result    &= is($ret,$element->{returnCheck},q[verify return value from command]);
+    
+    return $result;
+ }
+
+
+# check set command as subtest
+sub checkSet  {
+    my $element = shift;
+    my $targetHash = shift;
+
+    my $cmd = qq[$targetHash->{NAME} $element->{cmd}];
+    my $ret = main::CommandSet($targetHash,$cmd);
+
+    my $result  = is($mock->sub_tracking,$element->{subCheck},q[verify subroutine tracking]);
+    $result    &= is($ret,$element->{returnCheck},q[verify return value from command]);
+    
+    return $result;
+}; # subtest
+
+sub commandCheck {
+    my $modulename = shift;
+
+    my @filt_testDataArray = @mockData;
+    # print Dumper(@filt_testDataArray);
+
+    if (scalar @filt_testDataArray == 0) { pass("No testdata for module $modulename provided"); };
+
+    $mock = Test2::Mock->new(
+        track => 1, # enable call tracking if desired
+        class => 'main',
+    );  
+    
+    # Diable prototype mismatch warnings for redefined subs
+    local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /redefined|Prototype mismatch:/ };
+
+	foreach my $element (@filt_testDataArray)
+	{
+		next if (!exists($element->{testname}));
+    	$mock->clear_sub_tracking();
+	    my $targetHash = $::defs{$element->{targetName}};
+    
+        # prepare internals or anything else in deviceHash
+        $targetHash  = {%$targetHash, %$element{prep_hash}} if (exists($element->{prep_hash}));	
+
+        ## exevute custom commands
+        foreach my $cmd ( @{$element->{prep_commands}} )
+        {
+            $cmd =~ s/\$targetName/$targetHash->{NAME}/g;
+            main::AnalyzeCommand(undef,$cmd);
+        }
+        
+		#$element->{pre_code}->($target) if (exists($element->{pre_code}));
+     	
+        #my $ctx = context();
+
+        my $todo;
+        if ( exists $element->{todo}) {
+            $todo = Test2::Todo->new(reason => $element->{todo} ); 
+        }
+        
+        if(defined $element->{mocking}) {
+            $element->{mocking}->() ;
+        } elsif(defined $filt_testDataArray[0]{defaults}->{mocking})
+        {
+            $filt_testDataArray[0]{defaults}->{mocking}->();
+        } 
+
+
+        my ($op, $cmd) = split " ", $element->{cmd}, 2; 
+        $element->{cmd} = $cmd;
+        my $retVal = undef;
+        if ( $op eq q[set] ) {
+            $retVal = run_subtest(qq[Checking set commands for module: $modulename device: $targetHash->{NAME}: Test: $element->{testname} ], \&checkSet, {buffered => 1, inherit_trace => 1},$element, $targetHash);    
+        } elsif ( $op eq q[get] ) {
+            $retVal = run_subtest(qq[Checking set commands for module: $modulename device: $targetHash->{NAME}: Test: $element->{testname} ], \&checkGet, {buffered => 1, inherit_trace => 1},$element, $targetHash);    
+        } elsif ( $op eq q[attr] ) {
+            $retVal = run_subtest(qq[Checking set commands for module: $modulename device: $targetHash->{NAME}: Test: $element->{testname} ], \&checkAttr, {buffered => 1, inherit_trace => 1},$element, $targetHash);    
+        }
+
+        $mock->reset_all;
+		undef ($todo);
+        #$element->{post_code}->() if (exists($element->{post_code}));
+        
+        # Release Test2 context
+        #$ctx->pass_and_release() if $retVal;
+        #$ctx->fail_and_release($element->{testname}, $element) unless $retVal;
+	};
+
+    $mock = undef;
+}
+ 
+1;

--- a/t/FHEM/14_SD_UT/03_set.t
+++ b/t/FHEM/14_SD_UT/03_set.t
@@ -25,17 +25,9 @@ my $module = basename (dirname(__FILE__));
         },
     },
     {	
-        targetName 		=> 	q[SD_UT_Test_6],
-		testname        =>  q[set command fan_off],                 # Name of our setcommand
-        cmd   	        =>	q[set fan_off],      # Command to execute for test
-        prep_hash       => {                                # All Items listed here will be added to the devicehash bevore the test starts
-            cc1101_available  =>  1,
-            DIODev   =>  'open',
-        },
-        prep_commands   => [                                # Any FHEM custom command can be placed in here
-			'set $targetName ?', 
-        ],
-
+        targetName 		=> 	q[SD_UT_Test_6],				# Name of the definition which is tested
+		testname        =>  q[set command fan_off],         # Name of our setcommand
+        cmd   	        =>	q[set fan_off],      			# Command to execute for test
         # Check for arguments given to mocked sub
         subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#111110111110#R5' }; etc() } } } ,  
         returnCheck     => F(),    # Check for false return from command
@@ -46,9 +38,12 @@ my $module = basename (dirname(__FILE__));
         targetName 		=> 	q[SD_UT_Test_6],
 		testname        =>  q[set command 1_fan_low_speed],
         cmd	            =>	q[set 1_fan_low_speed],
+        prep_commands   => [                               # Any FHEM custom command can be placed in here, which will be called before the test is run
+			'attr $targetName repeats 4', 
+        ],
         
         returnCheck     => F(),    
-        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#011111111110#R5' }; etc() } } } ,
+        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#011111111110#R4' }; etc() } } } ,
     },
     {	
         targetName 		=> 	q[SD_UT_Test_1],

--- a/t/FHEM/14_SD_UT/03_set.t
+++ b/t/FHEM/14_SD_UT/03_set.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use File::Basename;
+
+# Testtool which supports DMSG Tests from SIGNALDuino_tool
+use Test2::SIGNALduino::FHEM_Command;
+use Test2::Tools::Compare qw{is U validator array hash};
+use Test2::Mock;
+
+our %defs;
+our $init_done;
+our $mock;
+
+my $module = basename (dirname(__FILE__));
+
+# This is the testdata, which will speify what to test and what to check
+@mockData = (
+    {
+        # Default mocking for every testrun in our loop
+        defaults    => {
+            mocking =>  sub { $mock->override ( IOWrite => sub { return @_ } );  } 
+        },
+    },
+    {	
+        targetName 		=> 	q[SD_UT_Test_6],
+		testname        =>  q[set command fan_off],                 # Name of our setcommand
+        cmd   	        =>	q[set fan_off],      # Command to execute for test
+        prep_hash       => {                                # All Items listed here will be added to the devicehash bevore the test starts
+            cc1101_available  =>  1,
+            DIODev   =>  'open',
+        },
+        prep_commands   => [                                # Any FHEM custom command can be placed in here
+			'set $targetName ?', 
+        ],
+
+        # Check for arguments given to mocked sub
+        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#111110111110#R5' }; etc() } } } ,  
+        returnCheck     => F(),    # Check for false return from command
+
+        #todo => 1, # Enable Todo block
+    },
+    {	
+        targetName 		=> 	q[SD_UT_Test_6],
+		testname        =>  q[set command 1_fan_low_speed],
+        cmd	            =>	q[set 1_fan_low_speed],
+        
+        returnCheck     => F(),    
+        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P29#011111111110#R5' }; etc() } } } ,
+    },
+    {	
+        targetName 		=> 	q[SD_UT_Test_1],
+		testname        =>  q[set command light_on],
+        cmd	            =>	q[set light_on],
+        
+        returnCheck     => F(),    
+        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P20#00111110000000000001111000011001#R5' }; etc() } } } ,
+    }
+
+	
+);
+        
+sub runTest {
+    Test2::SIGNALduino::FHEM_Command::commandCheck($module);
+
+    done_testing();
+	exit(0);
+}
+
+sub waitDone {
+
+	if ($init_done) 
+	{
+		runTest(@_);
+	} else {
+		InternalTimer(time()+0.2, &waitDone,@_);			
+	}
+
+}
+
+waitDone();
+
+1;

--- a/t/FHEM/14_SD_UT/fhem.cfg
+++ b/t/FHEM/14_SD_UT/fhem.cfg
@@ -3,3 +3,5 @@ attr dummyDuino dummy 1
 
 define SD_UT_Test_6 SD_UT Buttons_six E
 attr SD_UT_Test_6 model Buttons_six
+
+define SD_UT_Test_1 SD_UT RCnoName20_10 3E00


### PR DESCRIPTION
Adds test features for commands like set, get, attr

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [x] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Unittest enhancement
- [ ] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)

Testing set, get or attr commands needs much time, because there is no tool available.

* **What is the new behavior (if this is a feature change)?**

A tool is proved, to save time in writing tests


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
Defining a additional test need about 7 lines of code.

```
    {	
        targetName 		=> 	q[SD_UT_Test_1],
	testname        =>  q[set command light_on],
        cmd	            =>	q[set light_on],
        
        returnCheck     => F(),    
        subCheck        => hash { field 'IOWrite' => array { item 0 => hash { field 'args' => array { item hash { etc(); } ; item 'sendMsg'; item 'P20#00111110000000000001111000011001#R5' }; etc() } } } ,
    }
```