### PR TITLE
fix: Limit split two times

### DIFF
--- a/t/FHEM/00_SIGNALduino/01_SIGNALduino_Attr.t
+++ b/t/FHEM/00_SIGNALduino/01_SIGNALduino_Attr.t
@@ -295,7 +295,7 @@ my @mockData = (
         etc();
         },
       rValue => U(),
-  },  
+  },
 );
 plan (scalar @mockData + 2);  
 
@@ -334,7 +334,7 @@ InternalTimer(time()+1, sub() {
       my $p = $element->{plan} // 4;
       plan ($p);
 
-      my ($attrname,$value) = split(" ",$element->{input});
+      my ($attrname,$value) = split(" ",$element->{input},2);
       if (!exists $element->{pre_code}) {
         delete $attr{$element->{deviceName}}{$attrname}; 
         delete $defs{$element->{deviceName}}{QUEUE}; 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Unittest enhancement
- [ ] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)

Split has no limit for number of elements, but only two variables to be assigned with values. 
This causes a split on every whitespace in a attribute command:

```
2026.01.20 18:55:10 4: cc1101dummyDuino: Attr, Calling sub with args: del MatchList = 
2026.01.20 18:55:10 4: cc1101dummyDuino: Attr, Calling sub with args: set MatchList = {
2026.01.20 18:55:10 2: cc1101dummyDuino: Attr, {: Missing right curly or square bracket at (eval 32) line 1, at end of line
syntax error at (eval 32) line 1, at EOF
Execution of (eval 32) aborted due to compilation errors.
```
* **What is the new behavior (if this is a feature change)?**

Split is limited by two and splitting the command as it is required only at the first whitespace and not every whitespace.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

No error logged anymore:

```
2026.01.20 18:59:11 4: cc1101dummyDuino: Attr, Calling sub with args: del MatchList = 
2026.01.20 18:59:11 4: cc1101dummyDuino: Attr, Calling sub with args: set MatchList = { '34:MyModule' => '^u98#.{8}' } 
2026.01.20 18:59:11 4: cc1101dummyDuino: Attr, Calling sub with args: set MatchList = { '34:MyModule' => '^u98#.{8}' } 
```