### PR TITLE
Make coverage flags unique

### DIFF
--- a/.github/workflows/prove.yml
+++ b/.github/workflows/prove.yml
@@ -6,13 +6,16 @@ on:
       - '!push-action/**/**'
   pull_request:
 
+# Perl matrix versions are defined as repitory variables under settings->Actions secrets and variables
+# Example: '["5.32","5.34","5.36"]'.
+
 jobs:
   libModTests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        perl: [ '5.24', '5.28','5.32' ]
+        perl: ${{ fromJson(vars.PERL_VERSIONS) }}
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -22,28 +25,12 @@ jobs:
         install-modules-with: cpanm
         install-modules-args: --no-interactive -v --installdeps
 
-    - name: Install FHEM via debian nightly 
-      uses: fhem/setup-fhem@v1.0.1
-
-    - name: change ownership of /opt/fhem
-      run: |
-        sudo chown -R --reference=cpanfile /opt/fhem
-
     - name: run prove on perl modules (testscripts)
       run: |
         echo "::remove-matcher owner=perl::"
-        cp -R ${GITHUB_WORKSPACE}/lib/* ${FHEM_DIR}/lib/
         prove -j3 --exec 'perl -MDevel::Cover=-silent,1 -I lib -I FHEM ' -r -v t/SD_Protoco* t/FHEM/Devices > >(tee -a ${GITHUB_WORKSPACE}/testOutput.stdout) 2> >(tee -a ${GITHUB_WORKSPACE}/testOutput.stderr >&2)
       env:
         FHEM_DIR: /opt/fhem
-    - name: run prove fhem testsuite ${{ matrix.perl }}
-      run: |
-        cp -R ${GITHUB_WORKSPACE}/FHEM/* ${FHEM_DIR}/FHEM/
-        prove -j3 --exec 'perl -MDevel::Cover=-silent,1 fhem.pl -t' -I FHEM -v -r ${GITHUB_WORKSPACE}/t/FHEM/[0-9][0-9]_*  > >(tee -a ${GITHUB_WORKSPACE}/testOutput.stdout) 2> >(tee -a ${GITHUB_WORKSPACE}/testOutput.stderr >&2)
-      working-directory: /opt/fhem/
-      env:
-        FHEM_DIR: /opt/fhem
-
     - name: Create clover report for perl Modules
       run: cover -report clover
 
@@ -52,20 +39,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: clover.xml
         directory: ./cover_db
-        flags: unittests,perl,modules
+        flags: perl-modules-${{ matrix.perl }}
         name: perl modules (testscripts) ${{ matrix.perl }}
-
-    - name: Create clover report for fhem tests
-      working-directory: /opt/fhem/
-      run: cover -report clover
-
-    - uses: codecov/codecov-action@v5.5.2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: clover.xml
-        directory: /opt/fhem/cover_db
-        flags: unittests,fhem,modules
-        name: fhem (testscripts) ${{ matrix.perl }} 
 
     - uses: reviewdog/action-setup@v1
       if: always() && github.event_name == 'pull_request'
@@ -83,3 +58,56 @@ jobs:
             -filter-mode="file" \
             --diff="git diff ${{ github.base_ref }}" \
             
+  test_fhem_modules:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl: ${{ fromJson(vars.PERL_VERSIONS) }}
+        testdir:
+          - 00_SIGNALduino
+          - other_modules
+    name: FHEM ${{ matrix.perl }} / ${{ matrix.testdir }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: shogo82148/actions-setup-perl@v1.37.0
+      with:
+        perl-version: ${{ matrix.perl }}
+        install-modules-with: cpanm
+        install-modules-args: --no-interactive -v --installdeps
+
+    - name: Install FHEM via debian nightly
+      uses: fhem/setup-fhem@v1.0.1
+      
+    - name: change ownership of /opt/fhem
+      run: |
+        sudo chown -R --reference=cpanfile /opt/fhem
+
+    - name: patch FHEM installation with symlinks
+      run: bash .devcontainer/link_recursive.sh
+
+    - name: run prove fhem testsuite for ${{ matrix.testdir }}
+      run: |
+        if [ "${{ matrix.testdir }}" == "other_modules" ]; then
+          # Suche alle Testverzeichnisse außer 00_SIGNALduino und führe Tests im Batch aus
+          prove_dirs=$(find ${GITHUB_WORKSPACE}/t/FHEM/ -maxdepth 1 -type d -name '[0-9][0-9]_*' ! -name '00_SIGNALduino' -printf '%p ')
+          prove -j3 --exec 'perl -MDevel::Cover=-silent,1 fhem.pl -t' -I FHEM -v -r $prove_dirs > >(tee -a ${GITHUB_WORKSPACE}/testOutput.stdout) 2> >(tee -a ${GITHUB_WORKSPACE}/testOutput.stderr >&2)
+        else
+          # Führe nur Tests für 00_SIGNALduino aus
+          prove -j3 --exec 'perl -MDevel::Cover=-silent,1 fhem.pl -t' -I FHEM -v -r ${GITHUB_WORKSPACE}/t/FHEM/${{ matrix.testdir }}/  > >(tee -a ${GITHUB_WORKSPACE}/testOutput.stdout) 2> >(tee -a ${GITHUB_WORKSPACE}/testOutput.stderr >&2)
+        fi
+      working-directory: /opt/fhem/
+      env:
+        FHEM_DIR: /opt/fhem
+
+    - name: Create clover report for ${{ matrix.testdir }}
+      working-directory: /opt/fhem/
+      run: cover -report clover
+
+    - uses: codecov/codecov-action@v5.5.2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: clover.xml
+        directory: /opt/fhem/cover_db
+        flags: fhem-${{ matrix.testdir }}-${{ matrix.perl }}
+        name: fhem-${{ matrix.testdir }} ${{ matrix.perl }}


### PR DESCRIPTION
…nd enhance test job structure to seperate coverage tags and jobs

* **Please check if the PR fulfills these requirements**
<!-- Please do not remove these checkboxes. Check them if you have done the action behind this point -->
- [ ] Tests for the changes have been added / modified (needed for for bug fixes / features)
- [ ] commandref has been added / updated (needed for bug fixes / features)


<!--Please specify if this is a bugfix, feature or update of docs  -->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix (please link issue)
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Unittest enhancement
- [ ] other


* **What is the current behavior?** 
(You can also link to an open issue here, if this describes the current behavior)

Multiple uploads use the same codecov coverage flags, which is not recommened by codecov.


* **What is the new behavior (if this is a feature change)?**

- Every test uses its own flag. Tests are dived into fhem and perl tests.
- Every perl version provides a own suffix for the testflag 

For fhem tests:
- 00_SIGNALduino has it's own flag
- other_modules share their own common flag


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

Tests run now more paralell as before. 